### PR TITLE
Preview handler's response in dev tool.

### DIFF
--- a/packages/msw-dev-tool/package.json
+++ b/packages/msw-dev-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msw-dev-tool",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/msw-dev-tool/src/hook/useFlattenHandlersTable.tsx
+++ b/packages/msw-dev-tool/src/hook/useFlattenHandlersTable.tsx
@@ -6,7 +6,8 @@ import {
 } from "@tanstack/react-table";
 import { useHandlerStore } from "../lib/handlerStore";
 import { FlattenHandler } from "../lib";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
+import { PreviewHandler } from "../ui/Table/PreviewHandler";
 
 export const useFlattenHandlersTable = () => {
   const {
@@ -42,6 +43,24 @@ export const useFlattenHandlersTable = () => {
         cell: ({ row }) => (
           <div className="msw-dev-tool-center">{row.original.method}</div>
         ),
+      }),
+      columnHelper.accessor("handler", {
+        header: "Preview",
+        cell: ({ row }) => {
+          const handler = row.original.handler;
+          const [isOpen, setIsOpen] = useState(false);
+          return (
+            <>
+              <button onClick={() => setIsOpen(true)}>Preview</button>
+              {isOpen && (
+                <PreviewHandler
+                  handler={handler}
+                  onClose={() => setIsOpen(false)}
+                />
+              )}
+            </>
+          );
+        },
       }),
     ];
   }, []);

--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/PathParamSetter.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/PathParamSetter.tsx
@@ -1,0 +1,43 @@
+import { PathParams } from "msw";
+import React from "react";
+
+export const PathParamSetter = ({
+  paramValues,
+  onParamChange,
+}: {
+  paramValues?: PathParams<string>;
+  onParamChange: (key: string, value: string) => void;
+}) => {
+  return (
+    paramValues &&
+    Object.keys(paramValues).length > 0 && (
+      <>
+        <h3>Path Parameters</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {Object.entries(paramValues).map(([key, value]) => (
+            <div
+              key={key}
+              style={{ display: "flex", alignItems: "center", gap: "8px" }}
+            >
+              <label htmlFor={`param-${key}`} style={{ minWidth: "100px" }}>
+                {key}:
+              </label>
+              <input
+                id={`param-${key}`}
+                type="text"
+                value={value}
+                onChange={(e) => onParamChange(key, e.target.value)}
+                style={{
+                  padding: "4px 8px",
+                  borderRadius: "4px",
+                  border: "1px solid #ccc",
+                  width: "100%",
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  );
+};

--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/RequestPreview.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/RequestPreview.tsx
@@ -1,0 +1,95 @@
+import { PathParams } from "msw";
+import React, { useState } from "react";
+import { getPathWithParams, getTotalUrl } from "../../../utils/url";
+
+export const RequestPreview = ({
+  url,
+  paramValues,
+}: {
+  url: URL;
+  paramValues?: PathParams<string>;
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [response, setResponse] = useState<any>(null);
+
+  const finalPath = getPathWithParams(url, paramValues);
+  const totalUrl = getTotalUrl(url.origin, finalPath);
+
+  const handleFetch = () => {
+    setLoading(true);
+    setError(null);
+
+    fetch(totalUrl)
+      .then((res) => res.json())
+      .then((data) => {
+        setResponse(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err : new Error("Failed to fetch"));
+        setLoading(false);
+      });
+  };
+
+  return (
+    <div style={{ marginTop: "20px" }}>
+      <h3>Response</h3>
+      <div
+        style={{
+          fontFamily: "monospace",
+          wordBreak: "break-all",
+        }}
+      >
+        <button
+          onClick={handleFetch}
+          disabled={loading}
+          style={{
+            padding: "4px 12px",
+            borderRadius: "4px",
+            border: "1px solid #ccc",
+            backgroundColor: loading ? "#f5f5f5" : "white",
+            cursor: loading ? "not-allowed" : "pointer",
+          }}
+        >
+          {loading ? "Fetching..." : "Send Request"}
+        </button>
+
+        {error && (
+          <div
+            style={{
+              marginTop: "8px",
+              color: "#f44336",
+              backgroundColor: "#f5f5f5",
+            }}
+          >
+            Error: {error.message}
+          </div>
+        )}
+
+        {response && (
+          <div
+            style={{
+              marginTop: "8px",
+              maxHeight: "200px",
+              overflow: "scroll",
+              backgroundColor: "#f5f5f5",
+            }}
+          >
+            <pre
+              style={{
+                margin: 0,
+                overflow: "auto",
+                borderRadius: "4px",
+                fontFamily: "monospace",
+                wordBreak: "break-all",
+              }}
+            >
+              {JSON.stringify(response, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/index.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/index.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import { createPortal } from "react-dom";
+import { HttpHandler, matchRequestUrl, PathParams } from "msw";
+import { PathParamSetter } from "./PathParamSetter";
+import { RequestPreview } from "./RequestPreview";
+
+interface PreviewHandlerProps {
+  handler: HttpHandler;
+  onClose: () => void;
+}
+
+export const PreviewHandler = ({ handler, onClose }: PreviewHandlerProps) => {
+  const path = handler.info.path;
+  const url = new URL(String(path), location.href);
+  const { params } = matchRequestUrl(url, path, url.origin);
+
+  const [paramValues, setParamValues] = useState<
+    PathParams<string> | undefined
+  >(
+    params
+      ? Object.keys(params).reduce(
+          (acc, key) => ({
+            ...acc,
+            [key]: "",
+          }),
+          {}
+        )
+      : undefined
+  );
+
+  const handleParamChange = (key: string, value: string) => {
+    setParamValues((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  };
+
+  return createPortal(
+    <div
+      style={{
+        padding: "20px",
+        position: "fixed",
+        zIndex: 9999,
+        backgroundColor: "white",
+        boxShadow: "0 2px 10px rgba(0, 0, 0, 0.1)",
+        borderRadius: "8px",
+        width: "320px",
+      }}
+    >
+      <div style={{ position: "relative" }}>
+        <button
+          onClick={onClose}
+          style={{
+            position: "absolute",
+            right: 0,
+            top: 0,
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "1.2rem",
+            padding: "4px",
+          }}
+        >
+          ✕
+        </button>
+
+        <h2 style={{ marginBottom: "20px", paddingRight: "24px" }}>
+          Handler Preview
+        </h2>
+        <p style={{ fontSize: "0.8rem", color: "#666", overflow: "scroll" }}>
+          {url.toString()}
+        </p>
+        <PathParamSetter
+          paramValues={paramValues}
+          onParamChange={handleParamChange}
+        />
+        <RequestPreview url={url} paramValues={paramValues} />
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/packages/msw-dev-tool/src/utils/url.ts
+++ b/packages/msw-dev-tool/src/utils/url.ts
@@ -1,0 +1,29 @@
+import { PathParams } from "msw";
+
+/**
+ * Replace path parameters with path object and formatted path
+ */
+export const getPathWithParams = (
+  url: URL,
+  paramValues?: PathParams<string>
+): string => {
+  if (!paramValues) return url.pathname;
+
+  return url.pathname
+    .split("/")
+    .map((segment) => {
+      if (segment.startsWith(":")) {
+        const paramName = segment.slice(1); // remove ':'
+        return paramValues[paramName] || "undefined"; // replace with param value if exists, otherwise "undefined"
+      }
+      return segment;
+    })
+    .join("/");
+};
+
+/**
+ * Create full URL string
+ */
+export const getTotalUrl = (origin: string, path: string): string => {
+  return `${origin}${path}`;
+};


### PR DESCRIPTION
# Abstract
- Setting path params.
- Minor version update!
# Description
- If a developer clicks preview, he can see modal.
  - Modal has input fields that can control path params.
  - Modal has button that can send request and see the result of mocked api.
# Additional context
![image](https://github.com/user-attachments/assets/ca78c1ef-8dbd-4783-9539-efc24af54973)
![image](https://github.com/user-attachments/assets/a12ccf50-581f-488c-a0b6-b6265818c1d1)
