### PR TITLE
feat: set header

### DIFF
--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/KeyValueInputList.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/KeyValueInputList.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+
+interface KeyValueInputListProps {
+  items: Record<string, string>;
+  setItems: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+}
+
+export const KeyValueInputList = ({
+  items,
+  setItems,
+}: KeyValueInputListProps) => {
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+
+  const handleAdd = () => {
+    if (!key.trim() || !value.trim()) return;
+
+    setItems((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+    setKey("");
+    setValue("");
+  };
+
+  const handleDelete = (keyToDelete: string) => {
+    setItems((prev) => {
+      const newItems = { ...prev };
+      delete newItems[keyToDelete];
+      return newItems;
+    });
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          gap: "8px",
+          width: "100%",
+        }}
+      >
+        <input
+          type="text"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="Key"
+          style={{
+            padding: "8px",
+            borderRadius: "4px",
+            border: "1px solid #ccc",
+            width:"100px",
+          }}
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Value"
+          style={{
+            padding: "8px",
+            borderRadius: "4px",
+            border: "1px solid #ccc",
+            width: "100px",
+          }}
+        />
+        <button
+          onClick={handleAdd}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "#0066ff",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Add
+        </button>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {Object.entries(items).map(([key, value]) => (
+          <div
+            key={key}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "8px",
+              backgroundColor: "#f5f5f5",
+              borderRadius: "4px",
+              gap: "8px",
+            }}
+          >
+            <span style={{ flex: 1 }}>{key}</span>
+            <span style={{ flex: 1 }}>{value}</span>
+            <button
+              onClick={() => handleDelete(key)}
+              style={{
+                padding: "4px 8px",
+                backgroundColor: "#ff4444",
+                color: "white",
+                border: "none",
+                borderRadius: "4px",
+                cursor: "pointer",
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/PathParamSetter.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/PathParamSetter.tsx
@@ -27,6 +27,7 @@ export const PathParamSetter = ({
                 type="text"
                 value={value}
                 onChange={(e) => onParamChange(key, e.target.value)}
+                placeholder="value of path param"
                 style={{
                   padding: "4px 8px",
                   borderRadius: "4px",

--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/RequestPreview.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/RequestPreview.tsx
@@ -5,9 +5,11 @@ import { getPathWithParams, getTotalUrl } from "../../../utils/url";
 export const RequestPreview = ({
   url,
   paramValues,
+  headers = {},
 }: {
   url: URL;
   paramValues?: PathParams<string>;
+  headers?: Record<string, string>;
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -20,7 +22,12 @@ export const RequestPreview = ({
     setLoading(true);
     setError(null);
 
-    fetch(totalUrl)
+    fetch(totalUrl, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+    })
       .then((res) => res.json())
       .then((data) => {
         setResponse(data);

--- a/packages/msw-dev-tool/src/ui/Table/PreviewHandler/index.tsx
+++ b/packages/msw-dev-tool/src/ui/Table/PreviewHandler/index.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { HttpHandler, matchRequestUrl, PathParams } from "msw";
 import { PathParamSetter } from "./PathParamSetter";
 import { RequestPreview } from "./RequestPreview";
+import { KeyValueInputList } from "./KeyValueInputList";
 
 interface PreviewHandlerProps {
   handler: HttpHandler;
@@ -27,6 +28,7 @@ export const PreviewHandler = ({ handler, onClose }: PreviewHandlerProps) => {
         )
       : undefined
   );
+  const [headers, setHeaders] = useState<Record<string, string>>({});
 
   const handleParamChange = (key: string, value: string) => {
     setParamValues((prev) => ({
@@ -74,7 +76,9 @@ export const PreviewHandler = ({ handler, onClose }: PreviewHandlerProps) => {
           paramValues={paramValues}
           onParamChange={handleParamChange}
         />
-        <RequestPreview url={url} paramValues={paramValues} />
+        <h3>Headers</h3>
+        <KeyValueInputList items={headers} setItems={setHeaders} />
+        <RequestPreview url={url} paramValues={paramValues} headers={headers} />
       </div>
     </div>,
     document.body


### PR DESCRIPTION
close #5 

# Absctract 
- When fetch mocked api to preview res, a developer can set req header.

# Description
- Add Key, value
- Delete Key, value
- Show Key, value
- Req with header.

# Additional context
![image](https://github.com/user-attachments/assets/9b95f118-8f59-46a9-92f9-4c312012e5f8)
