### PR TITLE
chore: manage indirective dependency

### DIFF
--- a/packages/msw-dev-tool/package.json
+++ b/packages/msw-dev-tool/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.1",
-    "@rollup/plugin-node-resolve": "^15.0.2",
+    "@rollup/plugin-node-resolve": "^15.3.1",
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@tanstack/react-table": "^8.20.6",
-    "@tanstack/table-core": "^8.20.5",
     "@types/lodash": "^4.17.15",
     "immer": "^10.1.1",
     "lodash": "^4.17.21"

--- a/packages/msw-dev-tool/rollup.config.mjs
+++ b/packages/msw-dev-tool/rollup.config.mjs
@@ -39,10 +39,6 @@ export default [
         minimize: true,
       }),
     ],
-    /**
-     * When loading external modules, depending on pnpm’s package storage method
-     */
-    preserveSymlinks: true,
   },
   {
     input: "src/index.ts",
@@ -50,7 +46,14 @@ export default [
       file: "dist/types/index.d.ts",
       format: "es",
     },
-    external: [/\.css$/],
-    plugins: [dts()],
+    external: [/\.css$/, ...Object.keys(pkg.peerDependencies || {})],
+    plugins: [
+      dts({
+        compilerOptions: {
+          preserveSymlinks: false,
+          skipLibCheck: true,
+        },
+      }),
+    ],
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.20.6
         version: 8.20.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/table-core':
-        specifier: ^8.20.5
-        version: 8.20.5
       '@types/lodash':
         specifier: ^4.17.15
         version: 4.17.15
@@ -82,7 +79,7 @@ importers:
         specifier: ^24.0.1
         version: 24.1.0(rollup@3.29.5)
       '@rollup/plugin-node-resolve':
-        specifier: ^15.0.2
+        specifier: ^15.3.1
         version: 15.3.1(rollup@3.29.5)
       '@rollup/plugin-typescript':
         specifier: ^11.1.3


### PR DESCRIPTION
# Absctract
- remove indirective dep of directive dep
- change rollup config to include indirective dep

# Description
- remove `@tanstack/table-core` in dep
- When make types, skip check of lib and do not preserve symLink.