### PR TITLE
fix: when zustand state changed, remount component and its chuldren

### DIFF
--- a/packages/msw-dev-tool/src/ui/DevToolContent/HandlerDebugger/index.tsx
+++ b/packages/msw-dev-tool/src/ui/DevToolContent/HandlerDebugger/index.tsx
@@ -1,48 +1,52 @@
-import React, {
-  PropsWithChildren,
-  useState,
-  useEffect,
-} from "react";
+import React, { PropsWithChildren, useState, useEffect } from "react";
 import useUiControlStore from "../../../store/uiControlStore";
-import { matchRequestUrl, PathParams } from "msw";
+import { HttpHandler, matchRequestUrl, PathParams } from "msw";
 import { Flex, Heading, Text, Container as _Container } from "@radix-ui/themes";
 import { PathParamSetter } from "./PathParamSetter";
 import { KeyValueInputList } from "./KeyValueInputList";
 import { RequestPreview } from "./RequestPreview";
 
+/**
+ * - It uses `zustand` global state.
+ * - remounting of the inner component that uses local states.
+ * - To force a component to be remounted, use `key` prop.
+ */
 export const HandlerDebugger = () => {
   const { currentHandler: handler } = useUiControlStore();
 
-  const path = handler?.info.path ?? "";
+  const key = `${handler?.info.path}-${handler?.info.method}`;
+
+  return (
+    <Container>
+      {handler ? (
+        <_HandlerDebugger handler={handler} key={key} />
+      ) : (
+        <Text>Select a handler from the table to debug</Text>
+      )}
+    </Container>
+  );
+};
+
+const _HandlerDebugger = ({ handler }: { handler: HttpHandler }) => {
+  const path = handler?.info.path;
   const url = new URL(String(path), location.href);
   const { params } = matchRequestUrl(url, path, url.origin);
 
   const [paramValues, setParamValues] = useState<
     PathParams<string> | undefined
-  >(undefined);
-  const [headers, setHeaders] = useState<Record<string, string>>({});
-  const [searchParams, setSearchParams] = useState<Record<string, string>>({});
-
-  /**
-   * Initialize state to clear previous handler data
-   */
-  useEffect(() => {
-    if (params) {
-      setParamValues(
-        Object.keys(params).reduce(
+  >(
+    params
+      ? Object.keys(params).reduce(
           (acc, key) => ({
             ...acc,
             [key]: "",
           }),
           {}
         )
-      );
-    } else {
-      setParamValues(undefined);
-    }
-    setHeaders({});
-    setSearchParams({});
-  }, [handler]);
+      : undefined
+  );
+  const [headers, setHeaders] = useState<Record<string, string>>({});
+  const [searchParams, setSearchParams] = useState<Record<string, string>>({});
 
   const handleParamChange = (key: string, value: string) => {
     setParamValues((prev) => ({
@@ -50,16 +54,8 @@ export const HandlerDebugger = () => {
       [key]: value,
     }));
   };
-
-  if (!handler)
-    return (
-      <Container>
-        <Text>Select a handler from the table to debug</Text>
-      </Container>
-    );
-
   return (
-    <Container>
+    <>
       <Text className="msw-dt-sub-text" style={{ overflowX: "scroll" }}>
         {url.toString()}
       </Text>
@@ -83,13 +79,13 @@ export const HandlerDebugger = () => {
         headers={headers}
         searchParams={searchParams}
       />
-    </Container>
+    </>
   );
 };
 
 const Container = ({ children }: PropsWithChildren) => {
   return (
-    <_Container style={{ flex: 2, userSelect: "text",overflowY:"auto" }}>
+    <_Container style={{ flex: 2, userSelect: "text", overflowY: "auto" }}>
       <Flex direction="column" gap="4">
         <Heading as="h2" size="5">
           Debugger

--- a/packages/msw-dev-tool/src/ui/MSWDevTool.tsx
+++ b/packages/msw-dev-tool/src/ui/MSWDevTool.tsx
@@ -18,6 +18,7 @@ export const MSWDevTool = () => {
               borderRadius: "50%",
               width: "3.5rem",
               height: "3.5rem",
+              margin: "1rem",
             }}
           >
             M


### PR DESCRIPTION
# Abstract
- When debugger's handler is changed, remount and clear its local state. 
# Issues
close #16 
# Description
- Use `key` props
- Component that retrieves global state and components that use it are separated.
