### PR TITLE
feat: custom trigger

### DIFF
--- a/packages/msw-dev-tool/src/ui/MSWDevTool.tsx
+++ b/packages/msw-dev-tool/src/ui/MSWDevTool.tsx
@@ -1,29 +1,28 @@
-import React from "react";
-import { Button, Flex } from "@radix-ui/themes";
+import React, { ReactNode } from "react";
+import { Flex } from "@radix-ui/themes";
 import { Drawer } from "vaul";
 import { HandlerTable } from "./DevToolContent/HandlerTable";
 import { DialogDescription } from "@radix-ui/react-dialog";
 import { HandlerDebugger } from "./DevToolContent/HandlerDebugger";
 import { ThemeProvider } from "./ThemeProvider";
 import { ToolButtonGroup } from "./DevToolContent/ToolButtonGroup";
+import { DefaultDevToolTrigger } from "./Trigger";
 
-export const MSWDevTool = () => {
+interface MSWDevToolProps {
+  trigger?: ReactNode;
+}
+
+export const MSWDevTool = ({ trigger }: MSWDevToolProps) => {
   return (
     <ThemeProvider>
       <Drawer.Root>
-        <Drawer.Trigger asChild>
-          <Button
-            style={{
-              fontSize: "2rem",
-              borderRadius: "50%",
-              width: "3.5rem",
-              height: "3.5rem",
-              margin: "1rem",
-            }}
-          >
-            M
-          </Button>
-        </Drawer.Trigger>
+        {trigger ? (
+          <Drawer.Trigger asChild>{trigger}</Drawer.Trigger>
+        ) : (
+          <Drawer.Trigger asChild>
+            <DefaultDevToolTrigger />
+          </Drawer.Trigger>
+        )}
         <Drawer.Portal>
           <ThemeProvider>
             <Drawer.Overlay
@@ -46,8 +45,8 @@ export const MSWDevTool = () => {
                 backgroundColor: "#FFF",
                 outline: "none",
                 padding: "2rem",
-                display:"flex",
-                flexDirection:"column",
+                display: "flex",
+                flexDirection: "column",
               }}
             >
               <Flex align="center" justify="between">

--- a/packages/msw-dev-tool/src/ui/ThemeProvider.tsx
+++ b/packages/msw-dev-tool/src/ui/ThemeProvider.tsx
@@ -12,11 +12,7 @@ export const ThemeProvider = forwardRef<HTMLDivElement, PropsWithChildren>(
         ref={ref}
         style={{
           minHeight: 0,
-          maxHeight: 0,
-          position: "fixed",
-          top: 0,
-          left: 0,
-          zIndex: 999,
+          minWidth: 0,
         }}
       >
         {children}

--- a/packages/msw-dev-tool/src/ui/Trigger.tsx
+++ b/packages/msw-dev-tool/src/ui/Trigger.tsx
@@ -1,0 +1,29 @@
+import { Button, ButtonProps } from "@radix-ui/themes";
+import React, { forwardRef } from "react";
+
+export const DefaultDevToolTrigger = forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => {
+    return (
+      <Button
+        ref={ref}
+        style={{
+          fontSize: "2rem",
+          borderRadius: "50%",
+          width: "3.5rem",
+          height: "3.5rem",
+          margin: "1rem",
+          position: "fixed",
+          top: 0,
+          left: 0,
+          zIndex: 999,
+          cursor: "pointer",
+        }}
+        {...props}
+      >
+        M
+      </Button>
+    );
+  }
+);
+
+DefaultDevToolTrigger.displayName = "DefaultDevToolTrigger";


### PR DESCRIPTION
## Abstract
- `trigger` props in `<MSWDevTool/>`
- custom trigger

## Issues
<!-- If there are any issues that this PR fixes, please list them here. -->
<!-- #(issue_number) -->
close #42 

## Description
- User can custom dev tool trigger.
- Because of asChild works, I can't use ternary operator simply.
  - This is simple rendering process in `React`.
       1. JSX -> ReactElement
       2. Element -> DOM
  - `asChild` props is should be used for ReactElement.
  - JSX is a more comprehensive concept. 
  - Trigger must inject attrs to child (if `asChild === true`). But, this does not wait until jsx is converted to ReactElement.

## Additional Context
- [primitive](https://github.com/radix-ui/primitives/blob/main/packages/react/primitive/src/primitive.tsx)
- [Slot](https://github.com/radix-ui/primitives/blob/main/packages/react/slot/src/slot.tsx)
- [DialogTrigger](https://github.com/radix-ui/primitives/blob/main/packages/react/dialog/src/dialog.tsx#L97)