### PR TITLE
chore: send away turbopack

### DIFF
--- a/packages/docs/app/docs/_meta.tsx
+++ b/packages/docs/app/docs/_meta.tsx
@@ -18,6 +18,13 @@ const meta: MetaRecord = {
   debugger: {
     title: "Debugger",
   },
+  examples: {
+    title: <p className="font-extralight">EXAMPLES</p>,
+    type: "separator",
+  },
+  playground: {
+    title: "Playground",
+  },
 };
 
 export default meta;

--- a/packages/docs/app/docs/get-started/page.mdx
+++ b/packages/docs/app/docs/get-started/page.mdx
@@ -99,9 +99,11 @@ export const worker = setupDevToolWorker(...handlers);
 
 > **Note:** Unlike `msw`, `setupDevToolWorker()` returns a **Promise** that resolves to a worker instance.
 
+### 2. Integrate worker with browser
+
 For detailed information about **msw browser integration**, please refer to the [msw official documentation](https://mswjs.io/docs/integrations/browser).
 
-### 2. Add DevTool UI
+### 3. Add DevTool UI
 Add the `MSWDevTool` component and `msw-dev-tool.css` to your jsx:
 
 ```tsx {1-2}

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
     "build": "next build && pnpm postbuild",
     "start": "next start",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 2.7.0(@types/node@20.17.23)(typescript@5.6.3)
       msw-dev-tool:
         specifier: latest
-        version: 1.1.24(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(msw@2.7.0(@types/node@20.17.23)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zustand@5.0.2(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1))
+        version: 1.1.25(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(msw@2.7.0(@types/node@20.17.23)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zustand@5.0.2(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1))
       next:
         specifier: 15.2.1
         version: 15.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3907,8 +3907,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw-dev-tool@1.1.24:
-    resolution: {integrity: sha512-7ZffWNg+VQvTimDuQwn2+s6MDshW5+4jIh6Eqr8TeEWqu8i4PSEbEpiPWiT9EgqQhz6UKjfMNU4Ymt3us5YcIQ==}
+  msw-dev-tool@1.1.25:
+    resolution: {integrity: sha512-CMJvPLoYvtn5mAsqXm7anuTbOwSidPf6MOSCQrM6tUeuCBa1VqblbrKk+jriM7VatPtmYrVYFBVF+uQhcMlwxA==}
     peerDependencies:
       msw: ^2.7.0
       react: ^18.0.0
@@ -9609,7 +9609,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-dev-tool@1.1.24(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(msw@2.7.0(@types/node@20.17.23)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zustand@5.0.2(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)):
+  msw-dev-tool@1.1.25(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(msw@2.7.0(@types/node@20.17.23)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zustand@5.0.2(@types/react@18.3.18)(immer@10.1.1)(react@18.3.1)):
     dependencies:
       '@radix-ui/colors': 3.0.0
       '@radix-ui/react-dialog': 1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Abstract
<!-- What is the purpose of this PR? -->
- In a dev mode, turboPack cannot ignore `msw/browser`. turboPack is run with node.

## Issues
<!-- If there are any issues that this PR fixes, please list them here. -->
<!-- #(issue_number) -->

## Description
<!-- How does this PR fix the issues? -->
- Good bye, Turbopack.

## Additional Context
<!-- Any other context that would be helpful to review the PR. -->