### PR TITLE
chore: migrate docs to core/react and add turbo-based HMR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .yarn/*
+.turbo
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   ],
   "scripts": {
     "build": "yarn build:packages && yarn build:docs",
-    "build:packages": "yarn build:core && yarn build:msw-dev-tool && yarn build:react",
+    "build:packages": "turbo run build --filter=@msw-dev-tool/core --filter=@msw-dev-tool/react --filter=msw-dev-tool",
     "build:msw-dev-tool": "yarn workspace msw-dev-tool build",
     "build:core": "yarn workspace @msw-dev-tool/core build",
     "build:react": "yarn workspace @msw-dev-tool/react build",
     "build:docs": "yarn workspace docs build",
-    "dev": "yarn workspace docs dev",
+    "dev": "turbo run dev --filter=docs...",
+    "dev:example": "turbo run dev --filter=example...",
     "typecheck": "yarn workspace @msw-dev-tool/core typecheck && yarn workspace @msw-dev-tool/react typecheck && yarn workspace msw-dev-tool typecheck",
     "lint": "yarn workspace @msw-dev-tool/core lint && yarn workspace @msw-dev-tool/react lint",
     "test": "yarn workspace @msw-dev-tool/core test",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "ts-node": "^10.9.2",
+    "turbo": "^2.5.4",
     "typescript": "^5.8.3"
   },
   "packageManager": "yarn@4.5.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
   "description": "msw-dev-tool is a powerful library that enhances the Mock Service Worker (MSW) experience in React by providing an intuitive UI to control mock logic dynamically. It allows developers to modify mock data, adjust response statuses, and monitor API requests in real-time, making API mocking and debugging more seamless and efficient. 🚀",
   "scripts": {
     "build": "rollup -c",
+    "dev": "rollup -c -w",
     "clean": "rm -rf dist && rm -rf node_modules",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -62,4 +62,6 @@ const dtsConfigs = entries.map(({ input, file }) => ({
   external: externalPackages,
 }));
 
-export default defineConfig([...jsConfigs, ...dtsConfigs]);
+const isWatch = !!process.env.ROLLUP_WATCH;
+
+export default defineConfig(isWatch ? jsConfigs : [...jsConfigs, ...dtsConfigs]);

--- a/packages/docs/app/docs/(examples)/_components/DevToolTrigger.tsx
+++ b/packages/docs/app/docs/(examples)/_components/DevToolTrigger.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { MSWDevTool } from "msw-dev-tool";
+import { MSWDevTool } from "@msw-dev-tool/react";
 import { Button } from "nextra/components";
-import "msw-dev-tool/msw-dev-tool.css";
 import { Terminal } from "lucide-react";
 
 export const DevToolTrigger = () => {

--- a/packages/docs/mock/browser.ts
+++ b/packages/docs/mock/browser.ts
@@ -1,4 +1,4 @@
-import { setupDevToolWorker } from "msw-dev-tool";
+import { Handler, setupDevToolWorker } from "@msw-dev-tool/core";
 import { handlers } from "./handlers";
 
-export const worker = setupDevToolWorker(...handlers);
+export const worker = setupDevToolWorker(...(handlers as unknown as Handler[]));

--- a/packages/docs/next.config.ts
+++ b/packages/docs/next.config.ts
@@ -6,8 +6,9 @@ const withNextra = nextra({
 });
 
 const nextConfig: NextConfig = withNextra({
+  transpilePackages: ["@msw-dev-tool/core", "@msw-dev-tool/react"],
   /**
-   * This is required for the docs to use msw-dev-tool in production.
+   * This is required for the docs to use @msw-dev-tool/core in production.
    * The build works in a node environment, but msw/browser should be used strictly in a browser environment.
    * However, build checks all browser packages that are statically imported.
    */
@@ -15,6 +16,13 @@ const nextConfig: NextConfig = withNextra({
     if (isServer) {
       config.resolve.alias["msw/browser"] = false;
     }
+
+    // Watch workspace package rebuilds under node_modules/@msw-dev-tool/*
+    config.snapshot = {
+      ...config.snapshot,
+      managedPaths: [/^(.+?[\\/]node_modules[\\/])(?!@msw-dev-tool)/],
+    };
+
     return config;
   },
 });

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,12 +11,13 @@
     "clean": "rm -rf .next && rm -rf node_modules"
   },
   "dependencies": {
+    "@msw-dev-tool/core": "workspace:*",
+    "@msw-dev-tool/react": "workspace:*",
     "@next/third-parties": "^15.2.4",
     "clsx": "^2.1.1",
     "framer-motion": "^12.5.0",
     "lucide-react": "^0.479.0",
     "msw": "^2.7.0",
-    "msw-dev-tool": "workspace:*",
     "next": "15.2.1",
     "next-sitemap": "^4.2.3",
     "nextra": "^4.2.16",

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  optimizeDeps: {
+    exclude: ["@msw-dev-tool/core", "@msw-dev-tool/react"],
+  },
+  server: {
+    watch: {
+      // Workspace packages are symlinked under node_modules; watch their dist rebuilds.
+      ignored: ["**/node_modules/**", "!**/node_modules/@msw-dev-tool/**"],
+    },
+  },
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build": "rollup -c",
+    "dev": "rollup -c -w",
     "clean": "rm -rf dist && rm -rf node_modules",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -14,80 +14,83 @@ const externalPackages = [
   ...Object.keys(pkg.peerDependencies || {}),
   "msw/browser",
 ];
-export default [
-  {
-    input: "src/index.ts",
-    output: [
-      {
-        dir: "dist/cjs",
-        format: "cjs",
-        sourcemap: true,
-        preserveModules: true,
-        preserveModulesRoot: "src",
-        exports: "named",
-      },
-      {
-        dir: "dist/esm",
-        format: "esm",
-        sourcemap: true,
-        preserveModules: true,
-        preserveModulesRoot: "src",
-      },
-    ],
-    external: [...externalPackages],
-    plugins: [
-      peerDepsExternal(),
-      resolve(),
-      commonjs(),
-      typescript({
-        tsconfig: "./tsconfig.json",
-        declaration: false,
-      }),
-      postcss({
-        extract: false,
-        inject: false,
-        modules: false,
-        minimize: true,
-        plugins: [tailwind()],
-      }),
-    ],
-    onwarn(warning, warn) {
-      if (
-        warning.code === "MODULE_LEVEL_DIRECTIVE" &&
-        warning.message.includes("use client")
-      ) {
-        return;
-      }
+const isWatch = !!process.env.ROLLUP_WATCH;
 
-      /**
-       * FIXME: Silence warnings caused by the following issues
-       * @see {@link https://github.com/radix-ui/primitives/issues/3281}
-       */
-      if (
-        warning.code === "SOURCEMAP_ERROR" &&
-        warning.loc.file.includes("@radix-ui") &&
-        warning.loc.line === 1
-      ) {
-        return;
-      }
+const jsConfig = {
+  input: "src/index.ts",
+  output: [
+    {
+      dir: "dist/cjs",
+      format: "cjs",
+      sourcemap: true,
+      preserveModules: true,
+      preserveModulesRoot: "src",
+      exports: "named",
+    },
+    {
+      dir: "dist/esm",
+      format: "esm",
+      sourcemap: true,
+      preserveModules: true,
+      preserveModulesRoot: "src",
+    },
+  ],
+  external: [...externalPackages],
+  plugins: [
+    peerDepsExternal(),
+    resolve(),
+    commonjs(),
+    typescript({
+      tsconfig: "./tsconfig.json",
+      declaration: false,
+    }),
+    postcss({
+      extract: false,
+      inject: false,
+      modules: false,
+      minimize: true,
+      plugins: [tailwind()],
+    }),
+  ],
+  onwarn(warning, warn) {
+    if (
+      warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+      warning.message.includes("use client")
+    ) {
+      return;
+    }
 
-      warn(warning);
-    },
+    /**
+     * FIXME: Silence warnings caused by the following issues
+     * @see {@link https://github.com/radix-ui/primitives/issues/3281}
+     */
+    if (
+      warning.code === "SOURCEMAP_ERROR" &&
+      warning.loc.file.includes("@radix-ui") &&
+      warning.loc.line === 1
+    ) {
+      return;
+    }
+
+    warn(warning);
   },
-  {
-    input: "src/index.ts",
-    output: {
-      file: "dist/types/index.d.ts",
-      format: "es",
-    },
-    external: [/\.css$/, ...externalPackages],
-    plugins: [
-      dts({
-        compilerOptions: {
-          preserveSymlinks: false,
-          skipLibCheck: true,
-        },
-      }),
-    ],
+};
+
+const dtsConfig = {
+  input: "src/index.ts",
+  output: {
+    file: "dist/types/index.d.ts",
+    format: "es",
   },
-];
+  external: [/\.css$/, ...externalPackages],
+  plugins: [
+    dts({
+      compilerOptions: {
+        preserveSymlinks: false,
+        skipLibCheck: true,
+      },
+    }),
+  ],
+};
+
+export default isWatch ? [jsConfig] : [jsConfig, dtsConfig];

--- a/packages/react/src/ui/ThemeProvider.tsx
+++ b/packages/react/src/ui/ThemeProvider.tsx
@@ -3,8 +3,6 @@ import root from "react-shadow";
 import styles from "../style/msw-dev-tool.css";
 import { getCssPropertiesStyleSheet } from "../utils/style";
 
-const shadowSheet = getCssPropertiesStyleSheet(styles);
-
 export const ThemeProvider = forwardRef<HTMLDivElement, PropsWithChildren>(
   ({ children }, ref) => {
     const shadowHostRef = useRef<HTMLDivElement>(null);
@@ -12,11 +10,20 @@ export const ThemeProvider = forwardRef<HTMLDivElement, PropsWithChildren>(
     /**
      * - `@property` is not supported in shadow dom.
      * - So we need to use `adoptedStyleSheets` to apply the properties forcefully.
+     * - Create the stylesheet only in the browser; CSSStyleSheet is unavailable during SSR.
      */
     useEffect(() => {
-      if (shadowHostRef?.current?.shadowRoot) {
-        shadowHostRef.current.shadowRoot.adoptedStyleSheets = [shadowSheet];
+      const shadowRoot = shadowHostRef.current?.shadowRoot;
+      if (!shadowRoot) {
+        return;
       }
+
+      const shadowSheet = getCssPropertiesStyleSheet(styles);
+      if (!shadowSheet) {
+        return;
+      }
+
+      shadowRoot.adoptedStyleSheets = [shadowSheet];
     }, []);
 
     return (

--- a/packages/react/src/utils/style.ts
+++ b/packages/react/src/utils/style.ts
@@ -1,9 +1,13 @@
 export const getCssPropertiesStyleSheet = (styles: string) => {
+  if (typeof CSSStyleSheet === "undefined") {
+    return null;
+  }
+
   const shadowSheet = new CSSStyleSheet();
   shadowSheet.replaceSync(styles.replace(/:root/gu, ":host"));
   const properties = [];
   for (const rule of Array.from(shadowSheet.cssRules)) {
-    if (rule instanceof CSSPropertyRule) {
+    if (typeof CSSPropertyRule !== "undefined" && rule instanceof CSSPropertyRule) {
       if (rule.initialValue) {
         properties.push(`${rule.name}: ${rule.initialValue}`);
       }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "dev": {
+      "persistent": true,
+      "cache": false
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4312,6 +4312,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@turbo/darwin-64@npm:2.10.7":
+  version: 2.10.7
+  resolution: "@turbo/darwin-64@npm:2.10.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@turbo/darwin-arm64@npm:2.10.7":
+  version: 2.10.7
+  resolution: "@turbo/darwin-arm64@npm:2.10.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@turbo/linux-64@npm:2.10.7":
+  version: 2.10.7
+  resolution: "@turbo/linux-64@npm:2.10.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@turbo/linux-arm64@npm:2.10.7":
+  version: 2.10.7
+  resolution: "@turbo/linux-arm64@npm:2.10.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@turbo/windows-64@npm:2.10.7":
+  version: 2.10.7
+  resolution: "@turbo/windows-64@npm:2.10.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@turbo/windows-arm64@npm:2.10.7":
+  version: 2.10.7
+  resolution: "@turbo/windows-arm64@npm:2.10.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@tybys/wasm-util@npm:^0.10.3":
   version: 0.10.3
   resolution: "@tybys/wasm-util@npm:0.10.3"
@@ -6910,6 +6952,8 @@ __metadata:
   resolution: "docs@workspace:packages/docs"
   dependencies:
     "@eslint/eslintrc": "npm:^3"
+    "@msw-dev-tool/core": "workspace:*"
+    "@msw-dev-tool/react": "workspace:*"
     "@next/third-parties": "npm:^15.2.4"
     "@tailwindcss/postcss": "npm:^4"
     "@types/node": "npm:^20"
@@ -6921,7 +6965,6 @@ __metadata:
     framer-motion: "npm:^12.5.0"
     lucide-react: "npm:^0.479.0"
     msw: "npm:^2.7.0"
-    msw-dev-tool: "workspace:*"
     next: "npm:15.2.1"
     next-sitemap: "npm:^4.2.3"
     nextra: "npm:^4.2.16"
@@ -10963,11 +11006,12 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.28.1"
     ts-node: "npm:^10.9.2"
+    turbo: "npm:^2.5.4"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 
-"msw-dev-tool@workspace:*, msw-dev-tool@workspace:packages/msw-dev-tool":
+"msw-dev-tool@workspace:packages/msw-dev-tool":
   version: 0.0.0-use.local
   resolution: "msw-dev-tool@workspace:packages/msw-dev-tool"
   dependencies:
@@ -14323,6 +14367,35 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^2.5.4":
+  version: 2.10.7
+  resolution: "turbo@npm:2.10.7"
+  dependencies:
+    "@turbo/darwin-64": "npm:2.10.7"
+    "@turbo/darwin-arm64": "npm:2.10.7"
+    "@turbo/linux-64": "npm:2.10.7"
+    "@turbo/linux-arm64": "npm:2.10.7"
+    "@turbo/windows-64": "npm:2.10.7"
+    "@turbo/windows-arm64": "npm:2.10.7"
+  dependenciesMeta:
+    "@turbo/darwin-64":
+      optional: true
+    "@turbo/darwin-arm64":
+      optional: true
+    "@turbo/linux-64":
+      optional: true
+    "@turbo/linux-arm64":
+      optional: true
+    "@turbo/windows-64":
+      optional: true
+    "@turbo/windows-arm64":
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 10c0/06230af220cf6f9516286602003aa243840a684b381bffb5240c284d8eaa57d7ea0011af4253f3e8f2a19787c77bfd2e9788275dcf43a120f1aa556bc9ca14e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Migrate the docs playground from legacy `msw-dev-tool` to `@msw-dev-tool/core` + `@msw-dev-tool/react`
- Introduce Turborepo so `yarn dev` / `yarn dev:example` run package watch builds along the workspace dependency tree
- Add rollup `-w` scripts (skip dts in watch) and Vite/Next watch settings so workspace `dist` rebuilds hot-reload in the apps

## Test plan
- [ ] Run `yarn install`
- [ ] Run `yarn dev` and confirm core/react watch + docs Next start together
- [ ] Open the docs playground and verify DevTool loads with the new packages
- [ ] Edit a file in `@msw-dev-tool/core` or `@msw-dev-tool/react` and confirm the docs app picks up the rebuild
- [ ] Run `yarn dev:example` and confirm the example Vite app starts with the same watch pipeline


Made with [Cursor](https://cursor.com)