### PR TITLE
feat(core): replace zustand with useSyncExternalStore

### DIFF
--- a/.changeset/remove-zustand-core.md
+++ b/.changeset/remove-zustand-core.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": minor
+---
+
+Remove the `zustand` dependency. Handler state now uses a lightweight store with React `useSyncExternalStore`, so consumers no longer need to install or configure zustand.

--- a/README.md
+++ b/README.md
@@ -156,10 +156,9 @@ export default function App() {
 
 ## Internal Architecture
 
-This project is built on top of two core technologies:
+This project is built on top of:
 
 - **[MSW](https://mswjs.io/)**: The foundation for API mocking using Service Workers
-- **[Zustand](https://zustand.docs.pmnd.rs/)**: State management for the dev tool UI and handler control
 
 ### System Overview
 
@@ -169,19 +168,19 @@ The library consists of two main parts:
    - Wraps MSW's `setupWorker` with `setupDevToolWorker`
    - Manages handler state and behavior modifications
    - Provides APIs for runtime handler control
-   - Uses Zustand for state management
+   - Uses a lightweight store with React `useSyncExternalStore` (`useHandlerStore`)
 
 2. **React UI** (`@msw-dev-tool/react`):
    - React components for the dev tool interface
    - Handler table, debugger, and other UI features
-   - Communicates with core logic through Zustand store
+   - Communicates with core logic through `useHandlerStore`
    - Depends on `@msw-dev-tool/core` as a peer dependency
 
 ### How It Works
 
 1. **Worker Integration**: `setupDevToolWorker` wraps MSW's worker and adds additional capabilities for runtime control
-2. **State Management**: Zustand store maintains the state of all handlers, their behaviors, and API call history
-3. **Runtime Control**: The UI components interact with the Zustand store to modify handler behaviors, which are then applied to the MSW worker
+2. **State Management**: The core store maintains the state of all handlers, their behaviors, and API call history
+3. **Runtime Control**: The UI components interact with the store to modify handler behaviors, which are then applied to the MSW worker
 4. **API Monitoring**: Intercepts and logs all API calls made through MSW handlers
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:core": "yarn workspace @msw-dev-tool/core build",
     "build:react": "yarn workspace @msw-dev-tool/react build",
     "build:docs": "yarn workspace docs build",
-    "dev": "turbo run dev --filter=docs...",
+    "dev": "turbo run dev --filter=docs... --filter=example...",
     "dev:example": "turbo run dev --filter=example...",
     "typecheck": "yarn workspace @msw-dev-tool/core typecheck && yarn workspace @msw-dev-tool/react typecheck && yarn workspace msw-dev-tool typecheck",
     "lint": "yarn workspace @msw-dev-tool/core lint && yarn workspace @msw-dev-tool/react lint",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 - Internal logic of `msw-dev-tool/react`.
 - Manage core logic, type and schema.
-- It is based on `zustand` and `msw`.
+- It is based on `msw`, with a lightweight store and React `useSyncExternalStore`.
 - Getting ready!
 
 # Install

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,8 +76,7 @@
     }
   },
   "dependencies": {
-    "zod": "^3.24.2",
-    "zustand": "^5.0.2"
+    "zod": "^3.24.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -12,7 +12,6 @@ const externalPackages = [
   ...Object.keys(pkg.peerDependencies || {}),
   ...Object.keys(pkg.dependencies || {}),
   "msw/browser",
-  "zustand/middleware",
 ];
 
 const entries = [

--- a/packages/core/src/browser/createStore.ts
+++ b/packages/core/src/browser/createStore.ts
@@ -30,6 +30,7 @@ export const createStore = <T>(
   const setState: SetState<T> = (partial) => {
     const nextPartial =
       typeof partial === "function"
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         ? (partial as (state: T) => Partial<T>)(state)
         : partial;
     state = { ...state, ...nextPartial };
@@ -71,6 +72,7 @@ const readPersistedState = <T>(name: string): T | undefined => {
   try {
     const raw = sessionStorage.getItem(name);
     if (!raw) return undefined;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return JSON.parse(raw).state as T;
   } catch {
     return undefined;

--- a/packages/core/src/browser/createStore.ts
+++ b/packages/core/src/browser/createStore.ts
@@ -1,0 +1,78 @@
+type SetState<T> = (
+  partial: Partial<T> | ((state: T) => Partial<T>)
+) => void;
+type GetState<T> = () => T;
+type Subscribe = (listener: () => void) => () => void;
+
+export type StoreApi<T> = {
+  getState: GetState<T>;
+  setState: SetState<T>;
+  subscribe: Subscribe;
+};
+
+type StateCreator<T> = (set: SetState<T>, get: GetState<T>) => T;
+
+type PersistOptions<T> = {
+  name: string;
+  partialize: (state: T) => unknown;
+  getStoredState?: () => Partial<T> | undefined;
+};
+
+export const createStore = <T>(
+  createState: StateCreator<T>,
+  persistOptions?: PersistOptions<T>
+): StoreApi<T> => {
+  let state: T;
+  const listeners = new Set<() => void>();
+
+  const getState: GetState<T> = () => state;
+
+  const setState: SetState<T> = (partial) => {
+    const nextPartial =
+      typeof partial === "function"
+        ? (partial as (state: T) => Partial<T>)(state)
+        : partial;
+    state = { ...state, ...nextPartial };
+
+    if (persistOptions) {
+      try {
+        sessionStorage.setItem(
+          persistOptions.name,
+          JSON.stringify({ state: persistOptions.partialize(state) })
+        );
+      } catch {
+        // Ignore storage quota / unavailable errors.
+      }
+    }
+
+    listeners.forEach((listener) => listener());
+  };
+
+  const subscribe: Subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+
+  state = createState(setState, getState);
+
+  if (persistOptions) {
+    const stored =
+      persistOptions.getStoredState?.() ??
+      readPersistedState<Partial<T>>(persistOptions.name);
+    if (stored) {
+      state = { ...state, ...stored };
+    }
+  }
+
+  return { getState, setState, subscribe };
+};
+
+const readPersistedState = <T>(name: string): T | undefined => {
+  try {
+    const raw = sessionStorage.getItem(name);
+    if (!raw) return undefined;
+    return JSON.parse(raw).state as T;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -1,6 +1,4 @@
 import { setupWorker, SetupWorker } from "msw/browser";
-import { createStore } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
 import {
   appendFlattenHandler,
   buildTempHandler,
@@ -18,6 +16,7 @@ import {
   HttpHandlerBehavior,
 } from "../shared/types";
 import { initMSWDevToolStore } from "../shared/utils";
+import { createStore } from "./createStore";
 import { mergeStorageData } from "./storage";
 import { HandlerSchema } from "./schema";
 
@@ -55,118 +54,114 @@ export interface HandlerStoreState {
   removeTempHandler: (id: string) => void;
 }
 
-export const handlerStore = createStore<HandlerStoreState>()(
-  persist(
-    (set, get) => {
-      const lookupBehavior = (id: string) =>
-        findHandlerBehavior(get().flattenHandlers, id);
+export const handlerStore = createStore<HandlerStoreState>(
+  (set, get) => {
+    const lookupBehavior = (id: string) =>
+      findHandlerBehavior(get().flattenHandlers, id);
 
-      return {
-        flattenHandlers: [],
-        worker: null,
-        restHandlers: [],
-        handlerRowSelection: {},
-        setupDevToolWorker: async (...handlers: Handler[]) => {
-          const wrapped = wrapHandlersWithBehavior(handlers, lookupBehavior);
-          const worker = setupWorker(...wrapped);
+    return {
+      flattenHandlers: [],
+      worker: null,
+      restHandlers: [],
+      setupDevToolWorker: async (...handlers: Handler[]) => {
+        const wrapped = wrapHandlersWithBehavior(handlers, lookupBehavior);
+        const worker = setupWorker(...wrapped);
 
-          const { flattenHandlers, unsupportedHandlers } =
-            initMSWDevToolStore(worker);
+        const { flattenHandlers, unsupportedHandlers } =
+          initMSWDevToolStore(worker);
 
-          const { flattenHandlers: mergedHandlers } = mergeStorageData({
-            flattenHandlers,
-          });
+        const { flattenHandlers: mergedHandlers } = mergeStorageData({
+          flattenHandlers,
+        });
 
-          const rehydratedHandlers = rehydrateTempHandlers(
-            mergedHandlers,
-            lookupBehavior
-          );
-          registerTempHandlers(worker, rehydratedHandlers);
+        const rehydratedHandlers = rehydrateTempHandlers(
+          mergedHandlers,
+          lookupBehavior
+        );
+        registerTempHandlers(worker, rehydratedHandlers);
 
-          set({
-            worker,
-            flattenHandlers: rehydratedHandlers,
-            restHandlers: unsupportedHandlers,
-          });
+        set({
+          worker,
+          flattenHandlers: rehydratedHandlers,
+          restHandlers: unsupportedHandlers,
+        });
 
-          return worker;
-        },
-        resetMSWDevTool: () => {
-          const worker = get().getWorker();
-          worker.resetHandlers();
+        return worker;
+      },
+      resetMSWDevTool: () => {
+        const worker = get().getWorker();
+        worker.resetHandlers();
 
-          const { flattenHandlers, unsupportedHandlers } =
-            initMSWDevToolStore(worker);
+        const { flattenHandlers, unsupportedHandlers } =
+          initMSWDevToolStore(worker);
 
-          set({
-            worker,
-            flattenHandlers,
-            restHandlers: unsupportedHandlers,
-          });
-        },
-        addTempHandler: ({ data }) => {
-          const { handler, flattenHandler } = buildTempHandler(
-            data,
-            lookupBehavior
-          );
-          const worker = get().getWorker();
-          const flattenHandlers = appendFlattenHandler(
+        set({
+          worker,
+          flattenHandlers,
+          restHandlers: unsupportedHandlers,
+        });
+      },
+      addTempHandler: ({ data }) => {
+        const { handler, flattenHandler } = buildTempHandler(
+          data,
+          lookupBehavior
+        );
+        const worker = get().getWorker();
+        const flattenHandlers = appendFlattenHandler(
+          get().flattenHandlers,
+          flattenHandler
+        );
+        worker.use(handler);
+
+        set({
+          worker,
+          flattenHandlers,
+        });
+      },
+      getWorker: () => {
+        const worker = get().worker;
+        if (!worker) throw new Error("Worker is not initialized");
+        return worker;
+      },
+      getFlattenHandlerById: (id) =>
+        findFlattenHandlerById(get().flattenHandlers, id),
+      getHandlerBehavior: (id) => lookupBehavior(id),
+      setHandlerBehavior: (id, behavior) => {
+        set({
+          flattenHandlers: applyHandlerBehavior(
             get().flattenHandlers,
-            flattenHandler
-          );
-          worker.use(handler);
+            id,
+            behavior
+          ),
+        });
+      },
+      removeTempHandler: (id) => {
+        const worker = get().getWorker();
+        const flattenHandlers = removeTempHandlerFromList(
+          get().flattenHandlers,
+          id
+        );
 
-          set({
-            worker,
-            flattenHandlers,
-          });
-        },
-        getWorker: () => {
-          const worker = get().worker;
-          if (!worker) throw new Error("Worker is not initialized");
-          return worker;
-        },
-        getFlattenHandlerById: (id) =>
-          findFlattenHandlerById(get().flattenHandlers, id),
-        getHandlerBehavior: (id) => lookupBehavior(id),
-        setHandlerBehavior: (id, behavior) => {
-          set({
-            flattenHandlers: applyHandlerBehavior(
-              get().flattenHandlers,
-              id,
-              behavior
-            ),
-          });
-        },
-        removeTempHandler: (id) => {
-          const worker = get().getWorker();
-          const flattenHandlers = removeTempHandlerFromList(
-            get().flattenHandlers,
-            id
-          );
+        // MSW has no single-handler unregister — reset runtime handlers
+        // and re-register remaining temps.
+        worker.resetHandlers();
+        registerTempHandlers(worker, flattenHandlers);
 
-          // MSW has no single-handler unregister — reset runtime handlers
-          // and re-register remaining temps.
-          worker.resetHandlers();
-          registerTempHandlers(worker, flattenHandlers);
-
-          set({
-            worker,
-            flattenHandlers,
-          });
-        },
-      };
-    },
-    {
-      name: STORAGE_KEY,
-      storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) => ({
-        flattenHandlers: state.flattenHandlers.map(
-          ({ handler: _handler, ...rest }) => rest
-        ),
-      }),
-    }
-  )
+        set({
+          worker,
+          flattenHandlers,
+        });
+      },
+    };
+  },
+  {
+    name: STORAGE_KEY,
+    partialize: (state) => ({
+      flattenHandlers: state.flattenHandlers.map(
+        ({ handler: _handler, ...rest }) => rest
+      ),
+    }),
+  }
 );
 
 export const setupDevToolWorker = handlerStore.getState().setupDevToolWorker;

--- a/packages/core/src/browser/react.test.tsx
+++ b/packages/core/src/browser/react.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+import { useHandlerStore } from "./react";
+
+function UnstableSelectorComponent() {
+  const ids = useHandlerStore((state) =>
+    state.flattenHandlers.map((handler) => handler.id)
+  );
+
+  return <span data-testid="ids">{ids.length}</span>;
+}
+
+describe("useHandlerStore", () => {
+  it("does not loop when selector returns a new array reference", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<UnstableSelectorComponent />);
+    });
+
+    expect(container.querySelector("[data-testid='ids']")?.textContent).toBe(
+      "0"
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/packages/core/src/browser/react.ts
+++ b/packages/core/src/browser/react.ts
@@ -5,16 +5,19 @@ import type { HandlerStoreState } from "./handlerStore";
 export const useHandlerStore = <T>(
   selector: (state: HandlerStoreState) => T
 ): T => {
+  const stateRef = useRef(handlerStore.getState());
   const selectorRef = useRef(selector);
-  selectorRef.current = selector;
-
   const sliceRef = useRef<T>(selector(handlerStore.getState()));
 
   const getSnapshot = () => {
-    const nextSlice = selectorRef.current(handlerStore.getState());
-    if (!Object.is(sliceRef.current, nextSlice)) {
-      sliceRef.current = nextSlice;
+    const state = handlerStore.getState();
+
+    if (state !== stateRef.current || selector !== selectorRef.current) {
+      stateRef.current = state;
+      selectorRef.current = selector;
+      sliceRef.current = selectorRef.current(state);
     }
+
     return sliceRef.current;
   };
 

--- a/packages/core/src/browser/react.ts
+++ b/packages/core/src/browser/react.ts
@@ -1,7 +1,26 @@
-import { useStore } from "zustand";
+import { useRef, useSyncExternalStore } from "react";
 import { handlerStore } from "./handlerStore";
 import type { HandlerStoreState } from "./handlerStore";
 
 export const useHandlerStore = <T>(
   selector: (state: HandlerStoreState) => T
-): T => useStore(handlerStore, selector);
+): T => {
+  const selectorRef = useRef(selector);
+  selectorRef.current = selector;
+
+  const sliceRef = useRef<T>(selector(handlerStore.getState()));
+
+  const getSnapshot = () => {
+    const nextSlice = selectorRef.current(handlerStore.getState());
+    if (!Object.is(sliceRef.current, nextSlice)) {
+      sliceRef.current = nextSlice;
+    }
+    return sliceRef.current;
+  };
+
+  return useSyncExternalStore(
+    handlerStore.subscribe,
+    getSnapshot,
+    getSnapshot
+  );
+};

--- a/packages/core/src/browser/storage.test.ts
+++ b/packages/core/src/browser/storage.test.ts
@@ -18,7 +18,7 @@ describe("getStorageData", () => {
     expect(getStorageData()).toEqual({ flattenHandlers: [] });
   });
 
-  it("parses zustand persist state from sessionStorage", () => {
+  it("parses persisted state from sessionStorage", () => {
     const id = getRowId({ path: "/x", method: "get" });
     sessionStorage.setItem(
       STORAGE_KEY,

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
       {
         test: {
           name: "browser",
-          include: ["src/browser/**/*.test.ts"],
+          include: ["src/browser/**/*.test.ts", "src/browser/**/*.test.tsx"],
           environment: "happy-dom",
         },
       },

--- a/packages/docs/app/docs/(introduction)/get-started/page.mdx
+++ b/packages/docs/app/docs/(introduction)/get-started/page.mdx
@@ -72,47 +72,59 @@ The `msw-dev-tool` package is now **legacy** and will be deprecated in the futur
 Currently, msw-dev-tool is not compatible with React 19.
 </Callout>
 
-> **Note** To use msw-dev-tool, you need to install the following peer dependencies:
+#### New Package Structure (`@msw-dev-tool/core` + `@msw-dev-tool/react`)
+
+> **Note** Install the following peer dependencies:
 
 <Tabs items={["pnpm", "npm", "yarn"]}>
   <Tabs.Tab>
   ```bash copy
-  # If you don't use zustand
   pnpm add react react-dom
-  pnpm add -D zustand msw
-
-  # If you already use zustand
-  pnpm add react react-dom zustand
   pnpm add -D msw
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-  # If you don't use zustand
   npm install react react-dom
-  npm install --save-dev zustand msw
-
-  # If you already use zustand
-  npm install react react-dom zustand
   npm install --save-dev msw
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-  # If you don't use zustand
+  yarn add react react-dom
+  yarn add -D msw
+  ```
+  </Tabs.Tab>
+</Tabs>
+
+#### Legacy Package (`msw-dev-tool`)
+
+> **Note** The legacy package still requires `zustand` as a peer dependency:
+
+<Tabs items={["pnpm", "npm", "yarn"]}>
+  <Tabs.Tab>
+  ```bash copy
+  pnpm add react react-dom
+  pnpm add -D zustand msw
+  ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+  ```bash copy
+  npm install react react-dom
+  npm install --save-dev zustand msw
+  ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+  ```bash copy
   yarn add react react-dom
   yarn add -D zustand msw
-
-  # If you already use zustand
-  yarn add react react-dom zustand
-  yarn add -D msw
   ```
   </Tabs.Tab>
 </Tabs>
 
 For detailed setup instructions:
 - [MSW Setup Guide](https://mswjs.io/docs/getting-started/install)
-- [Zustand Setup Guide](https://zustand.docs.pmnd.rs/getting-started/introduction)
+- [Zustand Setup Guide](https://zustand.docs.pmnd.rs/getting-started/introduction) (legacy package only)
 
 ## Setup
 

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -27,7 +27,6 @@ export const metadata: Metadata = {
     "Dev tool to control mock logic, modify responses, and monitor API calls with msw.",
   keywords: [
     "msw",
-    "zustand",
     "mock",
     "service",
     "worker",

--- a/packages/docs/app/page.tsx
+++ b/packages/docs/app/page.tsx
@@ -33,10 +33,6 @@ export default function Home() {
               <a href="https://mswjs.io/" target="_blank" rel="noopener noreferrer" className="text-orange-400 hover:text-orange-300 underline underline-offset-2">
                 msw
               </a>
-              {" "}and{" "}
-              <a href="https://zustand-demo.pmnd.rs/" target="_blank" rel="noopener noreferrer" className="text-orange-400 hover:text-orange-300 underline underline-offset-2">
-                zustand
-              </a>
             </p>
           </div>
 

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -4,9 +4,6 @@ import react from "@vitejs/plugin-react";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ["@msw-dev-tool/core", "@msw-dev-tool/react"],
-  },
   server: {
     watch: {
       // Workspace packages are symlinked under node_modules; watch their dist rebuilds.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,7 +1453,6 @@ __metadata:
     typescript-eslint: "npm:^8.30.1"
     vitest: "npm:^4.1.10"
     zod: "npm:^3.24.2"
-    zustand: "npm:^5.0.2"
   peerDependencies:
     "@types/react": ^18 || ^19
     msw: ^2.7.0


### PR DESCRIPTION
## Summary
- Remove zustand from `@msw-dev-tool/core`
- Implement with `useSyncExternalStore`
- Users don't need to install & set zustand. So rewrite docs content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lightweight handler state management with session persistence.
  * Removed the need to install or configure Zustand for modular packages.
  * Improved React store subscriptions to prevent unnecessary render loops.

* **Documentation**
  * Updated installation, architecture, and setup guidance to reflect the new state-management approach.
  * Clarified peer dependencies for modular and legacy packages.

* **Bug Fixes**
  * Improved development startup to include example applications.
  * Updated browser test coverage for React store behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->