### PR TITLE
fix(react): Debugger dark-mode text and custom trigger isolation

### DIFF
--- a/.changeset/fix-debugger-dark-text.md
+++ b/.changeset/fix-debugger-dark-text.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/react": patch
+---
+
+Fix Debugger modal text becoming invisible on dark host pages, and isolate custom triggers from the default floating root overlay styles.

--- a/packages/react/src/style/msw-dev-tool.css
+++ b/packages/react/src/style/msw-dev-tool.css
@@ -361,6 +361,7 @@
   display: flex;
   flex-direction: column;
   background-color: #fff;
+  color: #111827;
   border-radius: 0.5rem;
   padding: 1rem 2rem;
   pointer-events: auto;
@@ -448,18 +449,6 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 0.875rem;
-}
-
-/* ===== Theme Root ===== */
-.msw-dt-root {
-  position: fixed;
-  z-index: 9999;
-  inset: 0;
-  pointer-events: none;
-}
-
-.msw-dt-root > * {
-  pointer-events: auto;
 }
 
 /* ===== Misc ===== */

--- a/packages/react/src/ui/MSWDevTool.tsx
+++ b/packages/react/src/ui/MSWDevTool.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useId } from "react";
+import React, { useId } from "react";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { HandlerTable } from "./DevToolContent/HandlerTable";
 import { ToolButtonGroup } from "./DevToolContent/ToolButtonGroup";
@@ -7,36 +7,40 @@ import { CloseButton } from "./Components/CloseButton";
 import { Flex } from "./Components/Flex";
 
 interface MSWDevToolProps {
-  trigger?: ReactNode;
+  trigger?: React.ReactElement<
+    Record<string, unknown>,
+    string | React.JSXElementConstructor<any>
+  >;
 }
 
 export const MSWDevTool = ({ trigger }: MSWDevToolProps) => {
   const titleId = useId();
 
   return (
-    <div className="msw-dt-root">
-      <Dialog.Root>
-        {trigger ? (
-          <Dialog.Trigger render={<button style={{ all: "unset", display: "contents" }} />}>{trigger}</Dialog.Trigger>
-        ) : (
-          <Dialog.Trigger render={<DefaultDevToolTrigger />} />
-        )}
-        <Dialog.Portal>
-          <Dialog.Backdrop className="msw-dt-dialog-backdrop" />
-          <Dialog.Popup className="msw-dt-dialog-popup-viewport" aria-labelledby={titleId}>
-            <div className="msw-dt-dialog-inner-bottom">
-              <Flex align="center" justify="space-between">
-                <Dialog.Title id={titleId} className="msw-dt-dialog-title">
-                  MSW DEV TOOL
-                </Dialog.Title>
-                <Dialog.Close render={<CloseButton />} />
-              </Flex>
-              <ToolButtonGroup />
-              <HandlerTable />
-            </div>
-          </Dialog.Popup>
-        </Dialog.Portal>
-      </Dialog.Root>
-    </div>
+    <Dialog.Root>
+      {trigger ? (
+        <Dialog.Trigger render={trigger} />
+      ) : (
+        <Dialog.Trigger render={<DefaultDevToolTrigger />} />
+      )}
+      <Dialog.Portal>
+        <Dialog.Backdrop className="msw-dt-dialog-backdrop" />
+        <Dialog.Popup
+          className="msw-dt-dialog-popup-viewport"
+          aria-labelledby={titleId}
+        >
+          <div className="msw-dt-dialog-inner-bottom">
+            <Flex align="center" justify="space-between">
+              <Dialog.Title id={titleId} className="msw-dt-dialog-title">
+                MSW DEV TOOL
+              </Dialog.Title>
+              <Dialog.Close render={<CloseButton />} />
+            </Flex>
+            <ToolButtonGroup />
+            <HandlerTable />
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };


### PR DESCRIPTION
## Abstract
Fix invisible Debugger modal text on dark host pages, and isolate custom triggers from the default floating root overlay styles.

## Issues
N/A

## Description
- Add `color: #111827` to `.msw-dt-dialog-inner-debugger` so text no longer inherits white from dark host pages (same treatment as Add Temp Handler / `.msw-dt-dialog-inner-center`).
- Stop wrapping the whole tool in a fixed full-viewport `.msw-dt-root`, and pass custom `trigger` elements directly to Base UI `Dialog.Trigger` via `render` so consumer styles and layout stay isolated from the default floating trigger.

## Additional Context
- `@msw-dev-tool/react` patch changeset included.
- Custom `trigger` prop type is now a `ReactElement` (must forward ref / spread props for Base UI composition).