### PR TITLE
chore: add changeset for Node sessions

### DIFF
--- a/.changeset/tidy-node-sessions.md
+++ b/.changeset/tidy-node-sessions.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": minor
+---
+
+Add Node MSW session support for controlling mock handlers from external tools.


### PR DESCRIPTION
Adds a changeset for the Node MSW session support merged in #115.