### PR TITLE
fix: unify workspace MSW types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "workspaces": [
     "packages/*"
   ],
+  "resolutions": {
+    "msw": "2.7.3"
+  },
   "scripts": {
     "build": "yarn build:packages && yarn build:docs",
     "build:packages": "turbo run build --filter=@msw-dev-tool/core --filter=@msw-dev-tool/react --filter=@msw-dev-tool/node-cli --filter=msw-dev-tool",

--- a/packages/docs/mock/browser.ts
+++ b/packages/docs/mock/browser.ts
@@ -1,4 +1,4 @@
-import { Handler, setupDevToolWorker } from "@msw-dev-tool/core";
+import { setupDevToolWorker } from "@msw-dev-tool/core";
 import { handlers } from "./handlers";
 
-export const worker = setupDevToolWorker(...(handlers as unknown as Handler[]));
+export const worker = setupDevToolWorker(...handlers);

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^22.10.5",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
-    "typescript": "~5.6.2"
+    "typescript": "^5.8.3"
   },
   "msw": {
     "workerDirectory": [

--- a/packages/example/src/mocks/browser.ts
+++ b/packages/example/src/mocks/browser.ts
@@ -1,7 +1,4 @@
-import { Handler, setupDevToolWorker } from "@msw-dev-tool/core/browser";
+import { setupDevToolWorker } from "@msw-dev-tool/core/browser";
 import { handlers } from "./handlers";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const typedHandlers = handlers as unknown as Handler[];
-
-export const workerPromise = setupDevToolWorker(...typedHandlers);
+export const workerPromise = setupDevToolWorker(...handlers);

--- a/packages/example/src/mocks/node.ts
+++ b/packages/example/src/mocks/node.ts
@@ -1,15 +1,12 @@
-import { Handler, setupDevToolServer } from "@msw-dev-tool/core/node";
+import { setupDevToolServer } from "@msw-dev-tool/core/node";
 import { handlers } from "./handlers";
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const typedHandlers = handlers as unknown as Handler[];
 
 let serverPromise: ReturnType<typeof setupDevToolServer> | null = null;
 
 export const ensureMswServer = async () => {
   if (!serverPromise) {
     serverPromise = (async () => {
-      const server = await setupDevToolServer(...typedHandlers);
+      const server = await setupDevToolServer(...handlers);
       server.listen({ onUnhandledRequest: "bypass" });
       return server;
     })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7116,7 +7116,7 @@ __metadata:
     next: "npm:15.2.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:~5.6.2"
+    typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 
@@ -10267,7 +10267,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"msw@npm:^2.7.0":
+"msw@npm:2.7.3":
   version: 2.7.3
   resolution: "msw@npm:2.7.3"
   dependencies:
@@ -13661,16 +13661,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.6.2":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
@@ -13678,16 +13668,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.6.2#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- pin MSW to a single workspace resolution
- align the example TypeScript peer context so Yarn hoists one MSW installation
- remove handler type-cast workarounds from the example and docs

## Verification
- core typecheck
- example: `tsc --noEmit`
- docs: `tsc --noEmit`