### PR TITLE
docs: refresh package setup guidance

### DIFF
--- a/packages/docs/app/docs/(features)/browser-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/browser-cli/page.mdx
@@ -2,7 +2,15 @@
 description: "Browser CLI for AI agents to control msw-dev-tool with Chrome DevTools Protocol"
 ---
 
-# Browser CLI (AI)
+import { Callout } from "nextra/components";
+
+# Browser CLI
+
+<Callout type="info">
+  **`@msw-dev-tool/browser-cli` is built for AI agents.** It exposes machine-readable,
+  one-shot commands so an agent can programmatically control an in-browser
+  msw-dev-tool session. It is not a human interactive TUI.
+</Callout>
 
 `@msw-dev-tool/browser-cli` lets an AI agent control an in-browser MSW Dev Tool
 session through Chrome DevTools Protocol (CDP). It uses the same handler commands
@@ -24,8 +32,9 @@ access.
   --user-data-dir=/tmp/msw-dev-tool-chrome
 ```
 
-Configure Chrome DevTools MCP to connect to that same endpoint. For Codex, add
-the following to `.codex/config.toml` and restart the MCP session:
+Configure your AI agent's Chrome DevTools MCP server to connect to the same
+endpoint. For example, in Codex add the following to `.codex/config.toml` and
+restart the MCP session:
 
 ```toml copy
 [mcp_servers.chrome-devtools]
@@ -33,7 +42,7 @@ command = "npx"
 args = ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"]
 ```
 
-The MCP and `msw-dev-tool-browser` can then inspect the same Chrome tabs. See
+Your MCP client and `msw-dev-tool-browser` can then inspect the same Chrome tabs. See
 the [Chrome DevTools MCP guide for connecting to a running Chrome instance](https://github.com/ChromeDevTools/chrome-devtools-mcp#connecting-to-a-running-chrome-instance)
 for other operating systems and remote-debugging details.
 

--- a/packages/docs/app/docs/(features)/node-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/node-cli/page.mdx
@@ -4,7 +4,7 @@ description: "Node CLI for AI agents to control msw-dev-tool programmatically"
 
 import { Callout, Tabs } from "nextra/components";
 
-# Node CLI (AI)
+# Node CLI
 
 <Callout type="info">
   **`@msw-dev-tool/node-cli` is built for AI agents.** It exposes machine-readable,
@@ -12,21 +12,14 @@ import { Callout, Tabs } from "nextra/components";
   session. It is not a human interactive TUI.
 </Callout>
 
-## Overview
+## Session lifecycle and reset
 
-In the browser, handler state lives in memory and is backed by `sessionStorage`.
+Each Node server process has its own Dev Tool session. The session starts from
+the handlers supplied to `setupDevToolServer()` and is discarded when that server
+process stops; restarting the server starts a new session from its current code
+handlers.
 
-In Node, `setupDevToolServer()` owns `SetupServer` and writes a **session snapshot**
-file. The CLI never touches another process's memory — it only reads/writes that
-snapshot. The owner process polls the file and applies changes to MSW.
-
-```text
-App process                         AI / CLI process
-setupDevToolServer()                msw-dev-tool set-behavior ...
-  └ handlerStore (memory)             └ writes snapshot file
-  └ polls snapshot file  <───────────┘
-  └ applies to SetupServer
-```
+The owner process polls the file every 200 ms and applies changes to MSW.
 
 ## Install
 
@@ -48,7 +41,7 @@ setupDevToolServer()                msw-dev-tool set-behavior ...
   </Tabs.Tab>
 </Tabs>
 
-## App setup (owner process)
+## App setup
 
 ```ts copy
 import { setupDevToolServer } from "@msw-dev-tool/core/node";

--- a/packages/docs/app/docs/(introduction)/get-started/page.mdx
+++ b/packages/docs/app/docs/(introduction)/get-started/page.mdx
@@ -21,116 +21,92 @@ export default function MdxLayout(props) {
 
 ## Installation
 
-### New Package Structure (Recommended)
-
-We recommend using the new modular package structure with `@msw-dev-tool/core` and `@msw-dev-tool/react`:
-
-{/* prettier-ignore */}
-<Tabs items={["pnpm", "npm", "yarn"]}>
-  <Tabs.Tab>
-  ```bash copy
-  pnpm add -D @msw-dev-tool/core @msw-dev-tool/react
-  ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-  ```bash copy
-  npm i @msw-dev-tool/core @msw-dev-tool/react --save-dev
-  ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-  ```bash copy
-  yarn add @msw-dev-tool/core @msw-dev-tool/react --dev
-  ```
-  </Tabs.Tab>
-</Tabs>
-
-### Legacy Package
-
-The `msw-dev-tool` package is now **legacy** and will be deprecated in the future. However, it is still **stable** and fully supported. For new projects, please use the new package structure above.
-
-{/* prettier-ignore */}
-<Tabs items={["pnpm", "npm", "yarn"]}>
-  <Tabs.Tab>
-  ```bash copy
-  pnpm add -D msw-dev-tool
-  ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-  ```bash copy
-  npm i msw-dev-tool --save-dev 
-  ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-  ```bash copy
-  yarn add msw-dev-tool --dev 
-  ```
-  </Tabs.Tab>
-</Tabs>
-
-### Install Peer Dependencies
 <Callout type="warning">
-Currently, msw-dev-tool is not compatible with React 19.
+  The legacy `msw-dev-tool` package is no longer maintained and is scheduled for
+  removal. Use the packages below for all new and existing integrations.
 </Callout>
 
-#### New Package Structure (`@msw-dev-tool/core` + `@msw-dev-tool/react`)
+### Browser UI
 
-> **Note** Install the following peer dependencies:
+Use the browser UI to inspect and control browser MSW handlers from your app.
+Install `@msw-dev-tool/core` for the MSW integration and `@msw-dev-tool/react`
+for the React-only UI.
 
+{/* prettier-ignore */}
 <Tabs items={["pnpm", "npm", "yarn"]}>
   <Tabs.Tab>
   ```bash copy
-  pnpm add react react-dom
-  pnpm add -D msw
+  pnpm add -D @msw-dev-tool/core @msw-dev-tool/react msw
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-  npm install react react-dom
-  npm install --save-dev msw
+  npm i @msw-dev-tool/core @msw-dev-tool/react msw --save-dev
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-  yarn add react react-dom
-  yarn add -D msw
+  yarn add @msw-dev-tool/core @msw-dev-tool/react msw --dev
   ```
   </Tabs.Tab>
 </Tabs>
 
-#### Legacy Package (`msw-dev-tool`)
+### Browser CLI
 
-> **Note** The legacy package still requires `zustand` as a peer dependency:
+Use the Browser CLI when an AI agent or script needs to control a browser MSW
+session through Chrome DevTools Protocol. It connects to the browser tab that
+already runs `setupDevToolWorker`.
 
+{/* prettier-ignore */}
 <Tabs items={["pnpm", "npm", "yarn"]}>
   <Tabs.Tab>
   ```bash copy
-  pnpm add react react-dom
-  pnpm add -D zustand msw
+  pnpm add -D @msw-dev-tool/browser-cli @msw-dev-tool/core msw
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-  npm install react react-dom
-  npm install --save-dev zustand msw
+  npm i @msw-dev-tool/browser-cli @msw-dev-tool/core msw --save-dev
   ```
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash copy
-  yarn add react react-dom
-  yarn add -D zustand msw
+  yarn add @msw-dev-tool/browser-cli @msw-dev-tool/core msw --dev
+  ```
+  </Tabs.Tab>
+</Tabs>
+
+### Node
+
+Use Node support when your MSW handlers run with `setupServer`, such as in an API
+server, test environment, or SSR process. Add `@msw-dev-tool/node-cli` when an AI
+agent or script needs to control that Node session.
+
+{/* prettier-ignore */}
+<Tabs items={["pnpm", "npm", "yarn"]}>
+  <Tabs.Tab>
+  ```bash copy
+  pnpm add -D @msw-dev-tool/core @msw-dev-tool/node-cli msw
+  ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+  ```bash copy
+  npm i @msw-dev-tool/core @msw-dev-tool/node-cli msw --save-dev
+  ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+  ```bash copy
+  yarn add @msw-dev-tool/core @msw-dev-tool/node-cli msw --dev
   ```
   </Tabs.Tab>
 </Tabs>
 
 For detailed setup instructions:
 - [MSW Setup Guide](https://mswjs.io/docs/getting-started/install)
-- [Zustand Setup Guide](https://zustand.docs.pmnd.rs/getting-started/introduction) (legacy package only)
 
 ## Setup
 
-### Using New Package Structure
-
-#### Browser (React UI)
+### Browser UI
 
 ##### 1. Integrate with msw
 Replace MSW's `setupWorker` with `setupDevToolWorker` from `@msw-dev-tool/core`:
@@ -146,67 +122,6 @@ export const worker = setupDevToolWorker(...handlers);
 ##### 2. Integrate worker with browser
 
 For detailed information about **msw browser integration**, please refer to the [msw official documentation](https://mswjs.io/docs/integrations/browser).
-
-###### Next.js Integration
-<Callout type="info">
-There is two ways to load worker in nextjs. Choose one of them.
-</Callout>
-
-1. **use `use` and `Suspense` to load worker**
-
-
-```ts
-export const initWorkerPromise =
-  typeof window === "undefined"
-    ? Promise.resolve()
-    : import("@/mock/browser")
-        .then(async (mod) => await mod.worker)
-        .then((worker) => {
-          worker.start({
-            onUnhandledRequest: "bypass",
-          });
-        });
-```
-- Import browser worker with Promise.
-
-```tsx
-import { PropsWithChildren, use } from "react";
-
-export const MSWProviderContent = ({ children }: PropsWithChildren) => {
-  use(initWorkerPromise);
-  return children;
-};
-```
-- To resolve the Promise, use `use` hook.
-
-```tsx
-import { Suspense } from "react";
-
-<Suspense fallback={null}>
-  <MSWProviderContent>
-    {children}
-  </MSWProviderContent>
-</Suspense>
-```
-- Wrap with `Suspense` to process the Promise.
-
-
-2. **Add webpack config in `next.config.ts`**
-
-```ts
-webpack: (config, { isServer }) => {
-  // ... other config
-  if (isServer) {
-    config.resolve.alias["msw/browser"] = false;
-  }
-  /// --- other config
-  return config;
-}
-```
-
-- `msw/browser` has no export in node env. So we need to exclude it from the build process.
-- This works fine, as it only ignores validation during the build process.
-
 
 ##### 3. Add DevTool UI
 Add the `MSWDevTool` component and `msw-dev-tool.css` to your jsx:
@@ -227,7 +142,13 @@ export default function App() {
 
 Also, you can customize the trigger ui. See [Custom Trigger](/docs/custom-trigger) for more details.
 
-#### Node (headless + AI CLI)
+### Browser CLI
+
+Start Chrome with remote debugging enabled, then use `msw-dev-tool-browser` to
+select the tab running `setupDevToolWorker` and control its handlers. See
+[Browser CLI](/docs/browser-cli) for the Chrome and MCP setup.
+
+### Node
 
 Use `@msw-dev-tool/core/node` when MSW runs in Node (`setupServer`).
 
@@ -238,104 +159,7 @@ const server = await setupDevToolServer(...handlers);
 server.listen();
 ```
 
-AI agents can control the Node session with `@msw-dev-tool/node-cli`. See [Node CLI (AI)](/docs/node-cli).
-
-### Using Legacy Package
-
-#### 1. Integrate with msw
-Replace MSW's `setupWorker` with `setupDevToolWorker` from `msw-dev-tool`:
-
-```ts copy
-import { setupDevToolWorker } from "msw-dev-tool";
-
-export const worker = setupDevToolWorker(...handlers);
-```
-
-> **Note:** Unlike `msw`, `setupDevToolWorker()` returns a **Promise** that resolves to a worker instance.
-
-#### 2. Integrate worker with browser
-
-For detailed information about **msw browser integration**, please refer to the [msw official documentation](https://mswjs.io/docs/integrations/browser).
-
-##### Next.js Integration
-<Callout type="info">
-There is two ways to load worker in nextjs. Choose one of them.
-</Callout>
-
-1. **use `use` and `Suspense` to load worker**
-
-
-```ts
-export const initWorkerPromise =
-  typeof window === "undefined"
-    ? Promise.resolve()
-    : import("@/mock/browser")
-        .then(async (mod) => await mod.worker)
-        .then((worker) => {
-          worker.start({
-            onUnhandledRequest: "bypass",
-          });
-        });
-```
-- Import browser worker with Promise.
-
-```tsx
-import { PropsWithChildren, use } from "react";
-
-export const MSWProviderContent = ({ children }: PropsWithChildren) => {
-  use(initWorkerPromise);
-  return children;
-};
-```
-- To resolve the Promise, use `use` hook.
-
-```tsx
-import { Suspense } from "react";
-
-<Suspense fallback={null}>
-  <MSWProviderContent>
-    {children}
-  </MSWProviderContent>
-</Suspense>
-```
-- Wrap with `Suspense` to process the Promise.
-
-
-2. **Add webpack config in `next.config.ts`**
-
-```ts
-webpack: (config, { isServer }) => {
-  // ... other config
-  if (isServer) {
-    config.resolve.alias["msw/browser"] = false;
-  }
-  /// --- other config
-  return config;
-}
-```
-
-- `msw/browser` has no export in node env. So we need to exclude it from the build process.
-- This works fine, as it only ignores validation during the build process.
-
-
-#### 3. Add DevTool UI
-Add the `MSWDevTool` component and `msw-dev-tool.css` to your jsx:
-
-```tsx {1-2}
-import { MSWDevTool } from "msw-dev-tool";
-import "msw-dev-tool/msw-dev-tool.css";
-
-export default function App() {
-  return (
-    <>
-      {/* Your app components */}
-      <MSWDevTool />
-    </>
-  );
-}
-```
-
-Also, you can customize the trigger ui. See [Custom Trigger](/docs/custom-trigger) for more details.
+AI agents can control the Node session with `@msw-dev-tool/node-cli`. See [Node CLI](/docs/node-cli).
 
 ## Questions & Support
 

--- a/packages/docs/app/docs/(introduction)/roadmap/page.mdx
+++ b/packages/docs/app/docs/(introduction)/roadmap/page.mdx
@@ -24,8 +24,3 @@ However, I plan to enable more specialized logic setup, such as [add temp handle
 
 With the addition of mock disable to behavior, the disable logic utilizing checkboxes is gone.
 I plan to keep this, and make it possible to disable the mock entirely with a switch-like ui.
-
-4. **Style isolation**  
-
-Due to a chronic bug in the UI, the UI style of the existing project and msw-dev-tool conflict.
-Currently, a solution to this is being considered.

--- a/packages/docs/app/docs/_meta.tsx
+++ b/packages/docs/app/docs/_meta.tsx
@@ -26,10 +26,10 @@ const meta: MetaRecord = {
     title: "Debugger",
   },
   "node-cli": {
-    title: "Node CLI (AI)",
+    title: "Node CLI",
   },
   "browser-cli": {
-    title: "Browser CLI (AI)",
+    title: "Browser CLI",
   },
   ui: {
     title: <Separator>UI</Separator>,


### PR DESCRIPTION
## Summary

- clarify the Browser UI, Browser CLI, and Node installation and setup paths
- document Node session lifecycle and add AI-focused Browser CLI guidance
- remove legacy, React 19, Next.js-specific, and obsolete roadmap guidance

## Testing

- `yarn workspace docs build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started guidance for the Browser UI, Browser CLI, and Node packages.
  * Added clearer Browser CLI guidance for AI-agent workflows and shared tab inspection.
  * Clarified Node CLI session lifecycle, process ownership, and reset behavior.
  * Simplified CLI naming throughout the documentation.
  * Removed outdated legacy setup instructions and a no-longer-relevant roadmap item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->