### PR TITLE
 fix(core): preserve network error responses

### DIFF
--- a/.changeset/preserve-network-errors.md
+++ b/.changeset/preserve-network-errors.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": patch
+---
+
+Preserve network error responses when wrapping request handlers.

--- a/packages/core/src/shared/domain/wrapHandlers.test.ts
+++ b/packages/core/src/shared/domain/wrapHandlers.test.ts
@@ -51,4 +51,28 @@ describe("wrapHandlersWithBehavior", () => {
     });
     expect(original).toHaveBeenCalledOnce();
   });
+
+  it("preserves network-error behavior from the original resolver", async () => {
+    const networkError = HttpResponse.error();
+    const handler = createHttpHandler(
+      HttpMethod.GET,
+      "/x",
+      async () => networkError
+    );
+
+    wrapHandlersWithBehavior([handler], () => CustomBehavior.DEFAULT);
+    const result = await handler.resolver({
+      request: new Request("http://localhost/x"),
+      requestId: "1",
+      params: {},
+      cookies: {},
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) {
+      throw new Error("Expected Response");
+    }
+    expect(result.type).toBe("error");
+    expect(result.status).toBe(0);
+  });
 });

--- a/packages/core/src/shared/domain/wrapHandlers.ts
+++ b/packages/core/src/shared/domain/wrapHandlers.ts
@@ -1,4 +1,5 @@
 import { HttpResponse } from "msw";
+import type { BehaviorResolverResult } from "../types";
 import { HttpHandlerBehavior } from "../types";
 import { getHandlerResponseByBehavior } from "../utils/handler";
 import { getRowId } from "../utils/store";
@@ -6,7 +7,7 @@ import { isHttpHandler } from "../utils/validate";
 
 const toStrictResolverResult = async (
   result: unknown
-): Promise<HttpResponse | undefined> => {
+): Promise<BehaviorResolverResult> => {
   const value = result instanceof Promise ? await result : result;
 
   if (value === undefined || value === null) {
@@ -15,6 +16,10 @@ const toStrictResolverResult = async (
 
   if (value instanceof HttpResponse) {
     return value;
+  }
+
+  if (value instanceof Response && value.type === "error") {
+    return HttpResponse.error();
   }
 
   if (value instanceof Response) {

--- a/packages/core/src/shared/types/msw.ts
+++ b/packages/core/src/shared/types/msw.ts
@@ -17,7 +17,7 @@ export type BehaviorResolverResult =
  */
 export type DevToolResponseResolver = (
   info: Parameters<HttpResponseResolver>[0]
-) => BehaviorResolverResult | PromiseLike<BehaviorResolverResult>;
+) => BehaviorResolverResult | Promise<BehaviorResolverResult>;
 
 export type HttpHandler = _HttpHandler & {
   resolver: DevToolResponseResolver;

--- a/packages/core/src/shared/utils/handler.ts
+++ b/packages/core/src/shared/utils/handler.ts
@@ -8,9 +8,13 @@ import {
 
 export type { BehaviorResolverResult };
 
+type MaybeBehaviorResolverResult =
+  | BehaviorResolverResult
+  | PromiseLike<BehaviorResolverResult>;
+
 export const getHandlerResponseByBehavior = async (
   behavior: HttpHandlerBehavior | undefined | string,
-  originalResolverCallback: () => BehaviorResolverResult
+  originalResolverCallback: () => MaybeBehaviorResolverResult
 ): Promise<BehaviorResolverResult> => {
   if (!behavior || behavior === CustomBehavior.DEFAULT) {
     return originalResolverCallback();

--- a/packages/core/src/shared/utils/handler.ts
+++ b/packages/core/src/shared/utils/handler.ts
@@ -10,7 +10,7 @@ export type { BehaviorResolverResult };
 
 type MaybeBehaviorResolverResult =
   | BehaviorResolverResult
-  | PromiseLike<BehaviorResolverResult>;
+  | Promise<BehaviorResolverResult>;
 
 export const getHandlerResponseByBehavior = async (
   behavior: HttpHandlerBehavior | undefined | string,


### PR DESCRIPTION
## Abstract
Fix `HttpResponse.error()` handling so wrapped handlers keep network-error behavior instead of degrading to an empty successful response.

## Issues
Fixes #107

## Description
`HttpResponse.error()` returns a native `Response` with `type: "error"`, not an `HttpResponse` instance. `wrapHandlersWithBehavior` now detects that response before the generic `Response` wrapping path and returns a network-error response.

The behavior callback type was also widened to support async resolver results that can resolve to native `Response` values.

A regression test covers the default behavior path and asserts that the wrapped resolver still returns `type: "error"` and `status: 0`.

## Additional Context
Verified with:
- `yarn workspace @msw-dev-tool/core test --run`
- `yarn workspace @msw-dev-tool/core typecheck`
- `yarn workspace @msw-dev-tool/core lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of resolver errors by consistently returning an error response with status `0`.
  - Preserved network-error responses, including their response type and error status.

- **Compatibility**
  - Resolver callbacks can now return results either synchronously or asynchronously without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->