### PR TITLE
feat(core): add custom handler response behavior

### DIFF
--- a/.changeset/friendly-custom-response.md
+++ b/.changeset/friendly-custom-response.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": minor
+---
+
+Add handler-level custom response behavior with configurable body, headers, and status.

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -9,7 +9,7 @@ vi.mock("msw/browser", () => ({
   }),
 }));
 
-import { BROWSER_CONTROL_KEY, BrowserControlBridge, setupDevToolWorker } from "./handlerStore";
+import { BROWSER_CONTROL_KEY, BrowserControlBridge, handlerStore, setupDevToolWorker } from "./handlerStore";
 import { STORAGE_KEY } from "../shared/const";
 
 const getBridge = (): BrowserControlBridge => {
@@ -60,5 +60,30 @@ describe("browser control bridge", () => {
       revision: reset.revision,
       state: { flattenHandlers: [{ id: handler.id, behavior: "default" }] },
     });
+  });
+
+  it("exposes custom response configuration through the handler store", async () => {
+    await setupDevToolWorker(http.get("/custom", () => HttpResponse.json({ original: true })));
+    const handler = handlerStore.getState().flattenHandlers[0]!;
+    const customResponse = {
+      body: "custom body",
+      headers: { "X-Custom": "yes" },
+      status: 202,
+    };
+
+    handlerStore.getState().setHandlerCustomResponse(handler.id, customResponse);
+    handlerStore.getState().setHandlerBehavior(handler.id, "custom response");
+
+    expect(handlerStore.getState().getHandlerCustomResponse(handler.id)).toEqual(customResponse);
+    const result = await handler.handler.resolver({
+      request: new Request("http://localhost/custom"),
+      requestId: "1",
+      params: {},
+      cookies: {},
+    });
+    if (!(result instanceof Response)) throw new Error("Expected Response");
+    expect(result.status).toBe(202);
+    expect(result.headers.get("X-Custom")).toBe("yes");
+    expect(await result.text()).toBe("custom body");
   });
 });

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -49,6 +49,8 @@ const mapState = (
   getFlattenHandlerById: base.getFlattenHandlerById,
   getHandlerBehavior: base.getHandlerBehavior,
   setHandlerBehavior: base.setHandlerBehavior,
+  getHandlerCustomResponse: base.getHandlerCustomResponse,
+  setHandlerCustomResponse: base.setHandlerCustomResponse,
   removeTempHandler: base.removeTempHandler,
 });
 

--- a/packages/core/src/browser/storage.test.ts
+++ b/packages/core/src/browser/storage.test.ts
@@ -60,6 +60,46 @@ describe("getStorageData", () => {
     });
   });
 
+  it("preserves a persisted custom response", () => {
+    const id = getRowId({ path: "/custom", method: "get" });
+    const customResponse = {
+      body: '{"source":"session"}',
+      headers: { "X-Source": "session" },
+      status: 202,
+    };
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        revision: 3,
+        state: {
+          flattenHandlers: [
+            {
+              id,
+              path: "/custom",
+              method: HttpMethod.GET,
+              behavior: CustomBehavior.CUSTOM_RESPONSE,
+              type: "default",
+              customResponse,
+            },
+          ],
+        },
+      })
+    );
+
+    expect(getBrowserStorageSnapshot()).toEqual({
+      revision: 3,
+      state: {
+        flattenHandlers: [
+          expect.objectContaining({
+            id,
+            behavior: CustomBehavior.CUSTOM_RESPONSE,
+            customResponse,
+          }),
+        ],
+      },
+    });
+  });
+
   it("reports a Zod validation error for an invalid persisted payload", () => {
     sessionStorage.setItem(
       STORAGE_KEY,

--- a/packages/core/src/browser/storage.ts
+++ b/packages/core/src/browser/storage.ts
@@ -6,7 +6,7 @@ import {
   PersistedStorageData,
   StorageData,
 } from "../shared/types";
-import { tempHandlerSchema } from "../shared/schema";
+import { customResponseSchema, tempHandlerSchema } from "../shared/schema";
 import { mergeStorageData as mergeStorageDataPure } from "../shared/utils/storage";
 
 export type BrowserStorageSnapshot = { revision: number; state: PersistedStorageData };
@@ -18,6 +18,7 @@ const persistedFlattenHandlerSchema = z.object({
   behavior: z.nativeEnum(HttpHandlerBehavior),
   type: z.enum(["temp", "default"]),
   tempInput: tempHandlerSchema.optional(),
+  customResponse: customResponseSchema.optional(),
 });
 
 const browserStoragePayloadSchema = z.object({

--- a/packages/core/src/node/snapshot/apply.ts
+++ b/packages/core/src/node/snapshot/apply.ts
@@ -43,6 +43,7 @@ export const applySnapshotToRuntime = (args: {
       behavior: entry.behavior,
       type: entry.type,
       tempInput: entry.tempInput,
+      customResponse: entry.customResponse,
     });
   }
 
@@ -55,16 +56,26 @@ export const applySnapshotToRuntime = (args: {
   const lookupBehavior = (id: string) =>
     snapshot.flattenHandlers.find((h) => h.id === id)?.behavior ??
     findHandlerBehavior(current, id);
+  const lookupCustomResponse = (id: string) =>
+    snapshot.flattenHandlers.find((h) => h.id === id)?.customResponse;
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const seedAsHandlers = seed as FlattenHandler[];
 
-  const next = rehydrateTempHandlers(seedAsHandlers, lookupBehavior).map(
-    (h) => {
+  const next = rehydrateTempHandlers(
+    seedAsHandlers,
+    lookupBehavior,
+    lookupCustomResponse
+  ).map((h) => {
       const fromSnap = snapshot.flattenHandlers.find((s) => s.id === h.id);
-      return fromSnap ? { ...h, behavior: fromSnap.behavior } : h;
-    }
-  );
+      return fromSnap
+        ? {
+            ...h,
+            behavior: fromSnap.behavior,
+            customResponse: fromSnap.customResponse,
+          }
+        : h;
+    });
 
   const tempsChanged =
     tempIdsSignature(current) !== tempIdsSignature(snapshot.flattenHandlers);
@@ -84,6 +95,7 @@ const serializableTempToSeed = (
   path: entry.path,
   method: entry.method,
   behavior: entry.behavior,
+  customResponse: entry.customResponse,
   type: "temp",
   tempInput: entry.tempInput,
 });

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -24,6 +24,7 @@ import {
   StringHttpStatusCode,
 } from "../../shared/types";
 import { FlattenHandler } from "../../shared/types";
+import { getRowId } from "../../shared/utils/store";
 
 const require = createRequire(import.meta.url);
 const tempDirs: string[] = [];
@@ -319,8 +320,13 @@ try {
             id: "a",
             path: "/a",
             method: HttpMethod.GET,
-            behavior: HttpHandlerBehavior.DELAY,
+            behavior: HttpHandlerBehavior.CUSTOM_RESPONSE,
             type: "default",
+            customResponse: {
+              body: "snapshot custom",
+              headers: { "X-Source": "snapshot" },
+              status: 202,
+            },
           },
         ],
       },
@@ -328,7 +334,66 @@ try {
 
     expect(next.map((h) => h.id).sort()).toEqual(["a", "b"]);
     expect(next.find((h) => h.id === "a")?.behavior).toBe(
-      HttpHandlerBehavior.DELAY
+      HttpHandlerBehavior.CUSTOM_RESPONSE
     );
+    expect(next.find((h) => h.id === "a")?.customResponse).toEqual({
+      body: "snapshot custom",
+      headers: { "X-Source": "snapshot" },
+      status: 202,
+    });
+  });
+
+  it("uses a custom response for a temp handler restored from a snapshot", async () => {
+    const runtime = {
+      use: () => undefined,
+      resetHandlers: () => undefined,
+      listHandlers: () => [],
+    };
+    const path = "/snapshot-temp";
+    const method = HttpMethod.GET;
+    const id = getRowId({ path, method });
+
+    const next = applySnapshotToRuntime({
+      runtime,
+      current: [],
+      snapshot: {
+        revision: 1,
+        flattenHandlers: [
+          {
+            id,
+            path,
+            method,
+            behavior: HttpHandlerBehavior.CUSTOM_RESPONSE,
+            type: "temp",
+            tempInput: {
+              path,
+              method,
+              contentType: MimeType.APPLICATION_JSON,
+              status: StringHttpStatusCode.OK,
+              response: '{"original":true}',
+            },
+            customResponse: {
+              body: "restored custom response",
+              headers: { "X-Source": "snapshot" },
+              status: 202,
+            },
+          },
+        ],
+      },
+    });
+
+    const handler = next[0]?.handler;
+    if (!handler) throw new Error("Expected restored temp handler");
+    const result = await handler.resolver({
+      request: new Request(`http://localhost${path}`, { method: "GET" }),
+      requestId: "1",
+      params: {},
+      cookies: {},
+    });
+
+    if (!(result instanceof Response)) throw new Error("Expected Response");
+    expect(result.status).toBe(202);
+    expect(result.headers.get("X-Source")).toBe("snapshot");
+    expect(await result.text()).toBe("restored custom response");
   });
 });

--- a/packages/core/src/node/snapshot/types.ts
+++ b/packages/core/src/node/snapshot/types.ts
@@ -3,7 +3,7 @@ import {
   HttpHandlerBehavior,
   HttpMethod,
 } from "../../shared/types";
-import { tempHandlerSchema } from "../../shared/schema";
+import { customResponseSchema, tempHandlerSchema } from "../../shared/schema";
 
 export const tempHandlerInputSchema = tempHandlerSchema;
 
@@ -14,6 +14,7 @@ export const serializableFlattenHandlerSchema = z.object({
   behavior: z.nativeEnum(HttpHandlerBehavior),
   type: z.enum(["temp", "default"]),
   tempInput: tempHandlerInputSchema.optional(),
+  customResponse: customResponseSchema.optional(),
 });
 
 export const sessionSnapshotSchema = z.object({

--- a/packages/core/src/shared/domain/handlers.test.ts
+++ b/packages/core/src/shared/domain/handlers.test.ts
@@ -10,8 +10,10 @@ import {
   appendFlattenHandler,
   getFlattenHandlerById,
   getHandlerBehavior,
+  getHandlerCustomResponse,
   removeTempHandler,
   setHandlerBehavior,
+  setHandlerCustomResponse,
 } from "./handlers";
 
 describe("getFlattenHandlerById / getHandlerBehavior", () => {
@@ -47,6 +49,24 @@ describe("setHandlerBehavior", () => {
     expect(getHandlerBehavior(next, id)).toBe(CustomBehavior.NETWORK_ERROR);
     expect(getHandlerBehavior(next, otherId)).toBe(HttpHandlerBehavior.DEFAULT);
     expect(handlers[0].behavior).toBe(HttpHandlerBehavior.DEFAULT);
+  });
+});
+
+describe("setHandlerCustomResponse", () => {
+  it("replaces only the selected handler's custom response", () => {
+    const id = getRowId({ path: "/a", method: "get" });
+    const otherId = getRowId({ path: "/b", method: "get" });
+    const handlers = [
+      createFlattenHandler({ id, path: "/a", method: HttpMethod.GET }),
+      createFlattenHandler({ id: otherId, path: "/b", method: HttpMethod.GET }),
+    ];
+
+    const first = setHandlerCustomResponse(handlers, id, { body: "first" });
+    const next = setHandlerCustomResponse(first, id, { body: "latest", status: 202 });
+
+    expect(getHandlerCustomResponse(next, id)).toEqual({ body: "latest", status: 202 });
+    expect(getHandlerCustomResponse(next, otherId)).toBeUndefined();
+    expect(getHandlerCustomResponse(handlers, id)).toBeUndefined();
   });
 });
 

--- a/packages/core/src/shared/domain/handlers.ts
+++ b/packages/core/src/shared/domain/handlers.ts
@@ -1,4 +1,5 @@
 import {
+  CustomResponse,
   FlattenHandler,
   HttpHandlerBehavior,
 } from "../types";
@@ -17,6 +18,11 @@ export const getHandlerBehavior = (
   return getFlattenHandlerById(handlers, id)?.behavior;
 };
 
+export const getHandlerCustomResponse = (
+  handlers: FlattenHandler[],
+  id: string
+): CustomResponse | undefined => getFlattenHandlerById(handlers, id)?.customResponse;
+
 export const setHandlerBehavior = (
   handlers: FlattenHandler[],
   id: string,
@@ -26,6 +32,15 @@ export const setHandlerBehavior = (
     handler.id === id ? { ...handler, behavior } : handler
   );
 };
+
+export const setHandlerCustomResponse = (
+  handlers: FlattenHandler[],
+  id: string,
+  customResponse: CustomResponse
+): FlattenHandler[] =>
+  handlers.map((handler) =>
+    handler.id === id ? { ...handler, customResponse } : handler
+  );
 
 export const removeTempHandler = (
   handlers: FlattenHandler[],

--- a/packages/core/src/shared/domain/tempHandler.test.ts
+++ b/packages/core/src/shared/domain/tempHandler.test.ts
@@ -66,6 +66,26 @@ describe("buildTempHandler", () => {
     expect(await first.text()).toBe('{"ok":true}');
     expect(await second.text()).toBe('{"ok":true}');
   });
+
+  it("uses the configured custom response", async () => {
+    const { handler } = buildTempHandler(
+      baseInput,
+      () => CustomBehavior.CUSTOM_RESPONSE,
+      () => ({ body: "temporary custom", headers: { "X-Temp": "yes" }, status: 202 })
+    );
+
+    const result = await handler.resolver({
+      request: new Request("http://localhost/temp", { method: "POST" }),
+      requestId: "1",
+      params: {},
+      cookies: {},
+    });
+
+    if (!(result instanceof Response)) throw new Error("Expected Response");
+    expect(result.status).toBe(202);
+    expect(result.headers.get("X-Temp")).toBe("yes");
+    expect(await result.text()).toBe("temporary custom");
+  });
 });
 
 describe("rehydrateTempHandlers", () => {

--- a/packages/core/src/shared/domain/tempHandler.ts
+++ b/packages/core/src/shared/domain/tempHandler.ts
@@ -6,6 +6,7 @@ import {
 } from "msw";
 import {
   FlattenHandler,
+  CustomResponse,
   HttpHandler,
   HttpHandlerBehavior,
   HttpMethod,
@@ -45,7 +46,8 @@ const toMswMethod = (method: HttpMethod): HttpMethods => {
 
 export const buildTempHandler = (
   data: TempHandlerInput,
-  getBehavior: (id: string) => HttpHandlerBehavior | undefined
+  getBehavior: (id: string) => HttpHandlerBehavior | undefined,
+  getCustomResponse: (id: string) => CustomResponse | undefined = () => undefined
 ): { handler: HttpHandler; flattenHandler: FlattenHandler } => {
   const {
     path,
@@ -80,15 +82,19 @@ export const buildTempHandler = (
 
   const created = new MswHttpHandler(toMswMethod(method), path, async () => {
     const behavior = getBehavior(id);
-    return await getHandlerResponseByBehavior(behavior, async () => {
-      await delay(responseDelay);
-      // Create a fresh response per request — body streams are single-use.
-      return new HttpResponse(response, {
-        status: Number(status),
-        statusText: statusText,
-        headers,
-      });
-    });
+    return await getHandlerResponseByBehavior(
+      behavior,
+      async () => {
+        await delay(responseDelay);
+        // Create a fresh response per request — body streams are single-use.
+        return new HttpResponse(response, {
+          status: Number(status),
+          statusText: statusText,
+          headers,
+        });
+      },
+      getCustomResponse(id)
+    );
   });
 
   if (!isHttpHandler(created)) {
@@ -114,7 +120,8 @@ export const buildTempHandler = (
  */
 export const rehydrateTempHandlers = (
   handlers: HydratableFlattenHandler[],
-  getBehavior: (id: string) => HttpHandlerBehavior | undefined
+  getBehavior: (id: string) => HttpHandlerBehavior | undefined,
+  getCustomResponse: (id: string) => CustomResponse | undefined = () => undefined
 ): FlattenHandler[] => {
   return handlers.flatMap((entry) => {
     if (entry.type !== "temp") {
@@ -123,7 +130,11 @@ export const rehydrateTempHandlers = (
     if (!entry.tempInput) {
       return [];
     }
-    const { flattenHandler } = buildTempHandler(entry.tempInput, getBehavior);
-    return [{ ...flattenHandler, behavior: entry.behavior }];
+    const { flattenHandler } = buildTempHandler(
+      entry.tempInput,
+      getBehavior,
+      getCustomResponse
+    );
+    return [{ ...flattenHandler, behavior: entry.behavior, customResponse: entry.customResponse }];
   });
 };

--- a/packages/core/src/shared/domain/wrapHandlers.test.ts
+++ b/packages/core/src/shared/domain/wrapHandlers.test.ts
@@ -52,6 +52,27 @@ describe("wrapHandlersWithBehavior", () => {
     expect(original).toHaveBeenCalledOnce();
   });
 
+  it("uses the custom response for a code-defined handler", async () => {
+    const handler = createHttpHandler(HttpMethod.GET, "/x");
+    wrapHandlersWithBehavior(
+      [handler],
+      () => CustomBehavior.CUSTOM_RESPONSE,
+      () => ({ body: "custom", headers: { "X-Handler": "yes" }, status: 203 })
+    );
+
+    const result = await handler.resolver({
+      request: new Request("http://localhost/x"),
+      requestId: "1",
+      params: {},
+      cookies: {},
+    });
+
+    if (!(result instanceof Response)) throw new Error("Expected Response");
+    expect(result.status).toBe(203);
+    expect(result.headers.get("X-Handler")).toBe("yes");
+    expect(await result.text()).toBe("custom");
+  });
+
   it("preserves network-error behavior from the original resolver", async () => {
     const networkError = HttpResponse.error();
     const handler = createHttpHandler(

--- a/packages/core/src/shared/domain/wrapHandlers.ts
+++ b/packages/core/src/shared/domain/wrapHandlers.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from "msw";
 import type { BehaviorResolverResult } from "../types";
-import { HttpHandlerBehavior } from "../types";
+import { CustomResponse, HttpHandlerBehavior } from "../types";
 import { getHandlerResponseByBehavior } from "../utils/handler";
 import { getRowId } from "../utils/store";
 import { isHttpHandler } from "../utils/validate";
@@ -35,7 +35,8 @@ const toStrictResolverResult = async (
  */
 export const wrapHandlersWithBehavior = <T>(
   handlers: T[],
-  getBehavior: (id: string) => HttpHandlerBehavior | undefined
+  getBehavior: (id: string) => HttpHandlerBehavior | undefined,
+  getCustomResponse: (id: string) => CustomResponse | undefined = () => undefined
 ): T[] => {
   return handlers.map((handler) => {
     if (!isHttpHandler(handler)) {
@@ -50,8 +51,10 @@ export const wrapHandlersWithBehavior = <T>(
       });
       const behavior = getBehavior(id);
 
-      return await getHandlerResponseByBehavior(behavior, () =>
-        toStrictResolverResult(originalResolver(args))
+      return await getHandlerResponseByBehavior(
+        behavior,
+        () => toStrictResolverResult(originalResolver(args)),
+        getCustomResponse(id)
       );
     };
     return handler;

--- a/packages/core/src/shared/schema/handler.test.ts
+++ b/packages/core/src/shared/schema/handler.test.ts
@@ -4,7 +4,11 @@ import {
   MimeType,
   StringHttpStatusCode,
 } from "../types";
-import { tempHandlerSchema, isValidHandlerPath } from "./handler";
+import {
+  customResponseSchema,
+  isValidHandlerPath,
+  tempHandlerSchema,
+} from "./handler";
 
 const validBase = {
   path: "/api/items",
@@ -35,5 +39,23 @@ describe("tempHandlerSchema", () => {
     expect(isValidHandlerPath("/users/:id")).toBe(true);
     expect(isValidHandlerPath("/files/*")).toBe(true);
     expect(isValidHandlerPath("not-a-path")).toBe(false);
+  });
+});
+
+describe("customResponseSchema", () => {
+  it("accepts an optional response body, headers, and valid HTTP status", () => {
+    expect(
+      customResponseSchema.safeParse({
+        body: '{"ok":true}',
+        headers: { "Content-Type": "application/json" },
+        status: 599,
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects statuses outside the HTTP response range", () => {
+    expect(customResponseSchema.safeParse({ status: 199 }).success).toBe(false);
+    expect(customResponseSchema.safeParse({ status: 600 }).success).toBe(false);
+    expect(customResponseSchema.safeParse({ status: 200.5 }).success).toBe(false);
   });
 });

--- a/packages/core/src/shared/schema/handler.test.ts
+++ b/packages/core/src/shared/schema/handler.test.ts
@@ -58,4 +58,26 @@ describe("customResponseSchema", () => {
     expect(customResponseSchema.safeParse({ status: 600 }).success).toBe(false);
     expect(customResponseSchema.safeParse({ status: 200.5 }).success).toBe(false);
   });
+
+  it.each([204, 205, 304])(
+    "rejects a body for HTTP %i",
+    (status) => {
+      expect(
+        customResponseSchema.safeParse({ status, body: "" }).success
+      ).toBe(false);
+    }
+  );
+
+  it("rejects headers that HttpResponse cannot construct", () => {
+    expect(
+      customResponseSchema.safeParse({
+        headers: { "invalid header": "value" },
+      }).success
+    ).toBe(false);
+    expect(
+      customResponseSchema.safeParse({
+        headers: { "X-Test": "line\nbreak" },
+      }).success
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/shared/schema/handler.ts
+++ b/packages/core/src/shared/schema/handler.ts
@@ -5,11 +5,34 @@ import {
   StringHttpStatusCode,
 } from "../types";
 
-export const customResponseSchema = z.object({
-  body: z.string().optional(),
-  headers: z.record(z.string()).optional(),
-  status: z.number().int().min(200).max(599).optional(),
-});
+const bodylessStatusCodes = new Set([204, 205, 304]);
+
+export const customResponseSchema = z
+  .object({
+    body: z.string().optional(),
+    headers: z.record(z.string()).optional(),
+    status: z.number().int().min(200).max(599).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.status && bodylessStatusCodes.has(data.status) && data.body !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `HTTP ${data.status} responses cannot include a body`,
+        path: ["body"],
+      });
+    }
+
+    if (!data.headers) return;
+    try {
+      new Headers(data.headers);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Invalid response headers",
+        path: ["headers"],
+      });
+    }
+  });
 
 export type CustomResponseSchema = z.infer<typeof customResponseSchema>;
 

--- a/packages/core/src/shared/schema/handler.ts
+++ b/packages/core/src/shared/schema/handler.ts
@@ -5,6 +5,14 @@ import {
   StringHttpStatusCode,
 } from "../types";
 
+export const customResponseSchema = z.object({
+  body: z.string().optional(),
+  headers: z.record(z.string()).optional(),
+  status: z.number().int().min(200).max(599).optional(),
+});
+
+export type CustomResponseSchema = z.infer<typeof customResponseSchema>;
+
 const isValidJson = (input: string) => {
   try {
     JSON.parse(input);

--- a/packages/core/src/shared/schema/index.ts
+++ b/packages/core/src/shared/schema/index.ts
@@ -22,6 +22,7 @@ export const httpHandlerSchema = z.object({
 export {
   tempHandlerSchema,
   handlerSchema,
+  customResponseSchema,
   isValidHandlerPath,
 } from "./handler";
-export type { TempHandlerSchema, HandlerSchema } from "./handler";
+export type { TempHandlerSchema, HandlerSchema, CustomResponseSchema } from "./handler";

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -3,9 +3,11 @@ import {
   buildTempHandler,
   getFlattenHandlerById as findFlattenHandlerById,
   getHandlerBehavior as findHandlerBehavior,
+  getHandlerCustomResponse as findHandlerCustomResponse,
   rehydrateTempHandlers,
   removeTempHandler as removeTempHandlerFromList,
   setHandlerBehavior as applyHandlerBehavior,
+  setHandlerCustomResponse as applyHandlerCustomResponse,
   wrapHandlersWithBehavior,
 } from "../domain";
 import {
@@ -46,13 +48,19 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
     (set, get) => {
       const lookupBehavior = (id: string) =>
         findHandlerBehavior(get().flattenHandlers, id);
+      const lookupCustomResponse = (id: string) =>
+        findHandlerCustomResponse(get().flattenHandlers, id);
 
       return {
         flattenHandlers: [],
         runtime: null,
         restHandlers: [],
         setupDevToolRuntime: async (...handlers: Handler[]) => {
-          const wrapped = wrapHandlersWithBehavior(handlers, lookupBehavior);
+          const wrapped = wrapHandlersWithBehavior(
+            handlers,
+            lookupBehavior,
+            lookupCustomResponse
+          );
           const runtime = options.createRuntime(wrapped);
 
           const { flattenHandlers, unsupportedHandlers } =
@@ -68,7 +76,8 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
 
           const rehydratedHandlers = rehydrateTempHandlers(
             mergedHandlers,
-            lookupBehavior
+            lookupBehavior,
+            lookupCustomResponse
           );
           registerTempHandlers(runtime, rehydratedHandlers);
 
@@ -102,7 +111,8 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
         addTempHandler: ({ data }) => {
           const { handler, flattenHandler } = buildTempHandler(
             data,
-            lookupBehavior
+            lookupBehavior,
+            lookupCustomResponse
           );
           const runtime = get().getRuntime();
           const flattenHandlers = appendFlattenHandler(
@@ -132,6 +142,16 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
               get().flattenHandlers,
               id,
               behavior
+            ),
+          });
+        },
+        getHandlerCustomResponse: (id) => lookupCustomResponse(id),
+        setHandlerCustomResponse: (id, response) => {
+          set({
+            flattenHandlers: applyHandlerCustomResponse(
+              get().flattenHandlers,
+              id,
+              response
             ),
           });
         },

--- a/packages/core/src/shared/store/types.ts
+++ b/packages/core/src/shared/store/types.ts
@@ -1,4 +1,4 @@
-import { FlattenHandler, Handler, HttpHandlerBehavior, TempHandlerInput } from "../types";
+import { CustomResponse, FlattenHandler, Handler, HttpHandlerBehavior, TempHandlerInput } from "../types";
 import type { HydratableFlattenHandler } from "../utils/storage";
 import { ListHandlersRuntime } from "../utils";
 import { PersistOptions, StoreApi } from "./createStore";
@@ -17,6 +17,8 @@ export type HandlerStoreBaseState = {
   getFlattenHandlerById: (id: string) => FlattenHandler | undefined;
   getHandlerBehavior: (id: string) => HttpHandlerBehavior | undefined;
   setHandlerBehavior: (id: string, behavior: HttpHandlerBehavior) => void;
+  getHandlerCustomResponse: (id: string) => CustomResponse | undefined;
+  setHandlerCustomResponse: (id: string, response: CustomResponse) => void;
   removeTempHandler: (id: string) => void;
 };
 

--- a/packages/core/src/shared/types/core.ts
+++ b/packages/core/src/shared/types/core.ts
@@ -13,6 +13,7 @@ export const CustomBehavior = {
   DELAY: "delay",
   RETURN_NULL: "return null",
   NETWORK_ERROR: "network error",
+  CUSTOM_RESPONSE: "custom response",
 } as const;
 export type CustomBehavior = ValueUnion<typeof CustomBehavior>;
 
@@ -21,6 +22,13 @@ export const HttpHandlerBehavior = {
   ...HttpErrorStatusCode,
 } as const;
 export type HttpHandlerBehavior = ValueUnion<typeof HttpHandlerBehavior>;
+
+/** Serializable response data returned by the custom response behavior. */
+export type CustomResponse = {
+  body?: string;
+  headers?: Record<string, string>;
+  status?: number;
+};
 
 /** Serializable input for rebuilding temporary handlers after persistence. */
 export type TempHandlerInput = {
@@ -40,6 +48,8 @@ export type FlattenHandler = {
   method: HttpMethod;
   handler: HttpHandler;
   behavior: HttpHandlerBehavior;
+  /** Response data used when the custom response behavior is selected. */
+  customResponse?: CustomResponse;
   type: "temp" | "default";
   /** Present on temp handlers so they can be rebuilt after JSON persistence. */
   tempInput?: TempHandlerInput;

--- a/packages/core/src/shared/utils/handler.test.ts
+++ b/packages/core/src/shared/utils/handler.test.ts
@@ -62,6 +62,49 @@ describe("getHandlerResponseByBehavior", () => {
     expect(result).toEqual(HttpResponse.error());
   });
 
+  it("returns the configured custom response", async () => {
+    const result = await getHandlerResponseByBehavior(
+      CustomBehavior.CUSTOM_RESPONSE,
+      async () => HttpResponse.json({ original: true }),
+      {
+        body: '{"custom":true}',
+        headers: { "Content-Type": "application/json", "X-Source": "dev-tool" },
+        status: 201,
+      }
+    );
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("Expected Response");
+    expect(result.status).toBe(201);
+    expect(result.statusText).toBe("Created");
+    expect(result.headers.get("X-Source")).toBe("dev-tool");
+    expect(await result.text()).toBe('{"custom":true}');
+  });
+
+  it("uses 200 OK when a custom response has no status configuration", async () => {
+    const result = await getHandlerResponseByBehavior(
+      CustomBehavior.CUSTOM_RESPONSE,
+      async () => HttpResponse.json({ original: true }),
+      { body: "default status" }
+    );
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) throw new Error("Expected Response");
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe("OK");
+  });
+
+  it("throws when CUSTOM_RESPONSE has not been configured", async () => {
+    await expect(
+      getHandlerResponseByBehavior(
+        CustomBehavior.CUSTOM_RESPONSE,
+        async () => HttpResponse.json({})
+      )
+    ).rejects.toThrow(
+      "Please configure a custom response before using this behavior."
+    );
+  });
+
   it("returns HttpResponse with status for error status codes", async () => {
     const result = await getHandlerResponseByBehavior(
       HttpErrorStatusCode.NOT_FOUND,

--- a/packages/core/src/shared/utils/handler.ts
+++ b/packages/core/src/shared/utils/handler.ts
@@ -1,6 +1,7 @@
 import { delay, HttpResponse, passthrough } from "msw";
 import {
   BehaviorResolverResult,
+  CustomResponse,
   CustomBehavior,
   HttpErrorStatusCode,
   HttpHandlerBehavior,
@@ -12,9 +13,75 @@ type MaybeBehaviorResolverResult =
   | BehaviorResolverResult
   | Promise<BehaviorResolverResult>;
 
+const DEFAULT_HTTP_STATUS = 200;
+
+const STANDARD_HTTP_STATUS_TEXT: Record<number, string> = {
+  200: "OK",
+  201: "Created",
+  202: "Accepted",
+  203: "Non-Authoritative Information",
+  204: "No Content",
+  205: "Reset Content",
+  206: "Partial Content",
+  207: "Multi-Status",
+  208: "Already Reported",
+  226: "IM Used",
+  300: "Multiple Choices",
+  301: "Moved Permanently",
+  302: "Found",
+  303: "See Other",
+  304: "Not Modified",
+  307: "Temporary Redirect",
+  308: "Permanent Redirect",
+  400: "Bad Request",
+  401: "Unauthorized",
+  402: "Payment Required",
+  403: "Forbidden",
+  404: "Not Found",
+  405: "Method Not Allowed",
+  406: "Not Acceptable",
+  407: "Proxy Authentication Required",
+  408: "Request Timeout",
+  409: "Conflict",
+  410: "Gone",
+  411: "Length Required",
+  412: "Precondition Failed",
+  413: "Content Too Large",
+  414: "URI Too Long",
+  415: "Unsupported Media Type",
+  416: "Range Not Satisfiable",
+  417: "Expectation Failed",
+  418: "I'm a teapot",
+  421: "Misdirected Request",
+  422: "Unprocessable Content",
+  423: "Locked",
+  424: "Failed Dependency",
+  425: "Too Early",
+  426: "Upgrade Required",
+  428: "Precondition Required",
+  429: "Too Many Requests",
+  431: "Request Header Fields Too Large",
+  451: "Unavailable For Legal Reasons",
+  500: "Internal Server Error",
+  501: "Not Implemented",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+  504: "Gateway Timeout",
+  505: "HTTP Version Not Supported",
+  506: "Variant Also Negotiates",
+  507: "Insufficient Storage",
+  508: "Loop Detected",
+  510: "Not Extended",
+  511: "Network Authentication Required",
+};
+
+const getDefaultStatusText = (status: number) =>
+  STANDARD_HTTP_STATUS_TEXT[status] ?? "";
+
 export const getHandlerResponseByBehavior = async (
   behavior: HttpHandlerBehavior | undefined | string,
-  originalResolverCallback: () => MaybeBehaviorResolverResult
+  originalResolverCallback: () => MaybeBehaviorResolverResult,
+  customResponse?: CustomResponse
 ): Promise<BehaviorResolverResult> => {
   if (!behavior || behavior === CustomBehavior.DEFAULT) {
     return originalResolverCallback();
@@ -35,6 +102,20 @@ export const getHandlerResponseByBehavior = async (
 
   if (behavior === CustomBehavior.NETWORK_ERROR) {
     return HttpResponse.error();
+  }
+
+  if (behavior === CustomBehavior.CUSTOM_RESPONSE) {
+    if (!customResponse) {
+      throw new Error(
+        "Please configure a custom response before using this behavior."
+      );
+    }
+    const status = customResponse.status ?? DEFAULT_HTTP_STATUS;
+    return new HttpResponse(customResponse.body ?? null, {
+      status,
+      statusText: getDefaultStatusText(status),
+      headers: customResponse.headers,
+    });
   }
 
   for (const code of Object.values(HttpErrorStatusCode)) {

--- a/packages/core/src/shared/utils/storage.test.ts
+++ b/packages/core/src/shared/utils/storage.test.ts
@@ -39,6 +39,34 @@ describe("mergeStorageData", () => {
     );
   });
 
+  it("overlays a saved custom response onto a matching handler", () => {
+    const id = getRowId({ path: "/a", method: "get" });
+    const customResponse = {
+      body: '{"cached":true}',
+      headers: { "X-Source": "storage" },
+      status: 201,
+    };
+    const merged = mergeStorageData(
+      { flattenHandlers: [makeFlatten({ id, path: "/a", method: HttpMethod.GET })] },
+      {
+        flattenHandlers: [
+          makeFlatten({
+            id,
+            path: "/a",
+            method: HttpMethod.GET,
+            behavior: CustomBehavior.CUSTOM_RESPONSE,
+            customResponse,
+          }),
+        ],
+      }
+    );
+
+    expect(merged.flattenHandlers[0]).toMatchObject({
+      behavior: CustomBehavior.CUSTOM_RESPONSE,
+      customResponse,
+    });
+  });
+
   it("keeps incoming handler when there is no saved match", () => {
     const id = getRowId({ path: "/new", method: "get" });
     const incoming = makeFlatten({

--- a/packages/core/src/shared/utils/storage.ts
+++ b/packages/core/src/shared/utils/storage.ts
@@ -22,6 +22,7 @@ export const mergeStorageData = (
         ...newHandler,
         behavior: savedHandler.behavior,
         type: savedHandler.type,
+        customResponse: savedHandler.customResponse,
       };
     }
     return newHandler;


### PR DESCRIPTION
## Abstract

Allow users to configure a handler response directly and easily.

## Issues

N/A

## Description

1. Allow users to configure handler responses directly with minimal setup.

2. Update the shared internal logic before it is consumed by the CLI and UI.

## Additional Context

- Includes support for configurable response body, headers, and status.
- Includes persistence and restoration of configured handler responses.
- Tests and type checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable custom responses, including response body, headers, and status.
  * Custom responses can now be saved and restored across browser sessions and runtime snapshots.

* **Bug Fixes**
  * Improved handling so custom response settings are preserved when handlers are updated, reloaded, or rehydrated.
  * Default response behavior now falls back to a standard success status when no status is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->