### PR TITLE
feat(cli): configure custom handler responses

### DIFF
--- a/.changeset/cli-custom-response.md
+++ b/.changeset/cli-custom-response.md
@@ -1,0 +1,8 @@
+---
+"@msw-dev-tool/cli-core": minor
+"@msw-dev-tool/node-cli": minor
+"@msw-dev-tool/browser-cli": minor
+"@msw-dev-tool/core": minor
+---
+
+Add CLI commands for storing handler custom response configuration in Node and browser sessions.

--- a/packages/browser-cli/src/index.ts
+++ b/packages/browser-cli/src/index.ts
@@ -2,7 +2,7 @@ import { commandUsage, findCommand, parseArgs, printJson } from "@msw-dev-tool/c
 import { CdpClient, listTargets } from "./cdp";
 import { CdpBrowserCliSession } from "./session";
 
-const usage = `msw-dev-tool-browser — AI-oriented CLI for @msw-dev-tool/core browser sessions\n\nCommands:\n  tabs\n${commandUsage()}\n\nAll commands except tabs require --cdp-url <http-url> and --target <target-id>.`;
+const usage = `msw-dev-tool-browser — AI-oriented CLI for @msw-dev-tool/core browser sessions\n\nCommands:\n  tabs\n${commandUsage()}\n\nset-custom-response stores response data only. Run set-behavior <id> "custom response" to apply it.\n\nAll commands except tabs require --cdp-url <http-url> and --target <target-id>.`;
 const requiredFlag = (flags: Record<string, string | boolean>, name: string) => {
   const value = flags[name];
   if (typeof value !== "string" || !value.trim()) throw new Error(`Missing required --${name}`);

--- a/packages/browser-cli/src/session.test.ts
+++ b/packages/browser-cli/src/session.test.ts
@@ -15,7 +15,17 @@ describe("CdpBrowserCliSession", () => {
       expression: expect.stringContaining("__MSW_DEV_TOOL_CONTROL__"),
     }));
     expect(call).toHaveBeenCalledWith("Runtime.evaluate", expect.objectContaining({
-      expression: expect.stringContaining("bridge.version !== 1"),
+      expression: expect.stringContaining("bridge.version !== 2"),
+    }));
+  });
+
+  it("sends custom response configuration through the page control bridge", async () => {
+    const call = vi.fn().mockResolvedValue({ result: { value: { revision: 3, handlerCount: 1 } } });
+    const session = new CdpBrowserCliSession({ call } as unknown as CdpClient);
+
+    await expect(session.setCustomResponse("handler-a", { status: 201, body: "created" })).resolves.toEqual({ revision: 3, handlerCount: 1 });
+    expect(call).toHaveBeenCalledWith("Runtime.evaluate", expect.objectContaining({
+      expression: expect.stringContaining('"setCustomResponse"'),
     }));
   });
 

--- a/packages/browser-cli/src/session.ts
+++ b/packages/browser-cli/src/session.ts
@@ -2,6 +2,7 @@ import { CliHandler, CliMutationResult, CliSession, CliSessionInfo } from "@msw-
 import {
   BROWSER_CONTROL_KEY,
   BROWSER_CONTROL_PROTOCOL_VERSION,
+  CustomResponse,
   HttpHandlerBehavior,
   TempHandlerInput,
 } from "@msw-dev-tool/core/shared";
@@ -26,6 +27,7 @@ export class CdpBrowserCliSession implements CliSession {
   public list(): Promise<CliHandler[]> { return this.invoke("list"); }
   public get(id: string): Promise<CliHandler | undefined> { return this.invoke("get", [id]); }
   public setBehavior(id: string, behavior: HttpHandlerBehavior): Promise<CliMutationResult> { return this.invoke("setBehavior", [id, behavior]); }
+  public setCustomResponse(id: string, response: CustomResponse): Promise<CliMutationResult> { return this.invoke("setCustomResponse", [id, response]); }
   public addTemp(data: TempHandlerInput): Promise<CliMutationResult> { return this.invoke("addTemp", [data]); }
   public removeTemp(id: string): Promise<CliSessionInfo> { return this.invoke("removeTemp", [id]); }
   public reset(): Promise<CliSessionInfo> { return this.invoke("reset"); }

--- a/packages/cli-core/src/commands.ts
+++ b/packages/cli-core/src/commands.ts
@@ -1,4 +1,5 @@
 import {
+  customResponseSchema,
   HttpHandlerBehavior,
   tempHandlerSchema,
 } from "@msw-dev-tool/core/shared";
@@ -19,6 +20,17 @@ const withMetadata = (
   result: JsonResult,
   context: CliCommandContext
 ): JsonResult => ({ ...result, ...(context.metadata ?? {}) });
+
+const parseCustomResponse = (value: string) => {
+  try {
+    return customResponseSchema.parse(JSON.parse(value) as unknown);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error("Custom response must be valid JSON");
+    }
+    throw error;
+  }
+};
 
 export const commands: CliCommand[] = [
   {
@@ -54,6 +66,20 @@ export const commands: CliCommand[] = [
       if (!id || !behavior) throw new Error("Usage: set-behavior <id> <behavior>");
       return withMetadata(
         { ok: true, ...(await context.session.setBehavior(id, parseBehavior(behavior))) },
+        context
+      );
+    },
+  },
+  {
+    name: "set-custom-response",
+    usage: "set-custom-response <id> --json '<customResponseJson>'",
+    async execute(context, { flags, positionals }) {
+      const id = positionals[1];
+      if (!id || typeof flags.json !== "string") {
+        throw new Error("Usage: set-custom-response <id> --json '<customResponseJson>'");
+      }
+      return withMetadata(
+        { ok: true, ...(await context.session.setCustomResponse(id, parseCustomResponse(flags.json))) },
         context
       );
     },

--- a/packages/cli-core/src/index.test.ts
+++ b/packages/cli-core/src/index.test.ts
@@ -3,12 +3,13 @@ import { CliHandler, CliSession, commands } from "./index";
 
 const handler: CliHandler = { id: "a", path: "/a", method: "get", behavior: "default", type: "default" };
 const createSession = (): CliSession => {
-  const handlers = [handler];
+  const handlers = [{ ...handler }];
   let revision = 0;
   const info = () => ({ revision, handlerCount: handlers.length });
   return {
     describe: async () => info(), list: async () => handlers, get: async (id) => handlers.find((item) => item.id === id),
     setBehavior: async (id, behavior) => { const item = handlers.find((entry) => entry.id === id); if (!item) throw new Error(`Handler not found for id: ${id}`); item.behavior = behavior; revision += 1; return { ...info(), handler: item }; },
+    setCustomResponse: async (id, customResponse) => { const item = handlers.find((entry) => entry.id === id); if (!item) throw new Error(`Handler not found for id: ${id}`); item.customResponse = customResponse; revision += 1; return { ...info(), handler: item }; },
     addTemp: async () => { throw new Error("not used"); }, removeTemp: async () => { throw new Error("not used"); }, reset: async () => info(),
   };
 };
@@ -19,8 +20,28 @@ describe("shared CLI commands", () => {
     await expect(command.execute({ session: createSession() }, { flags: {}, positionals: ["set-behavior", "a", "delay"] })).resolves.toMatchObject({ ok: true, revision: 1, handler: { id: "a", behavior: "delay" } });
   });
 
+  it("stores a validated custom response without changing behavior", async () => {
+    const command = commands.find((item) => item.name === "set-custom-response")!;
+    await expect(command.execute(
+      { session: createSession() },
+      { flags: { json: '{"status":201,"body":"created","headers":{"X-Created":"yes"}}' }, positionals: ["set-custom-response", "a"] }
+    )).resolves.toMatchObject({
+      ok: true,
+      revision: 1,
+      handler: { behavior: "default", customResponse: { status: 201, body: "created" } },
+    });
+  });
+
   it("rejects a missing command argument before reaching the adapter", async () => {
     const command = commands.find((item) => item.name === "remove-temp")!;
     await expect(command.execute({ session: createSession() }, { flags: {}, positionals: ["remove-temp"] })).rejects.toThrow("Usage: remove-temp <id>");
+  });
+
+  it("rejects invalid custom response input before reaching the adapter", async () => {
+    const command = commands.find((item) => item.name === "set-custom-response")!;
+    await expect(command.execute(
+      { session: createSession() },
+      { flags: { json: "{" }, positionals: ["set-custom-response", "a"] }
+    )).rejects.toThrow("Custom response must be valid JSON");
   });
 });

--- a/packages/cli-core/src/types.ts
+++ b/packages/cli-core/src/types.ts
@@ -1,13 +1,11 @@
-import type { HttpHandlerBehavior, TempHandlerInput } from "@msw-dev-tool/core/shared";
+import type {
+  CustomResponse,
+  HttpHandlerBehavior,
+  PersistedFlattenHandler,
+  TempHandlerInput,
+} from "@msw-dev-tool/core/shared";
 
-export type CliHandler = {
-  id: string;
-  path: string;
-  method: string;
-  behavior: HttpHandlerBehavior;
-  type: "temp" | "default";
-  tempInput?: TempHandlerInput;
-};
+export type CliHandler = PersistedFlattenHandler;
 
 export type CliSessionInfo = {
   revision: number;
@@ -22,6 +20,7 @@ export type CliSession = {
   list(): Promise<CliHandler[]>;
   get(id: string): Promise<CliHandler | undefined>;
   setBehavior(id: string, behavior: HttpHandlerBehavior): Promise<CliMutationResult>;
+  setCustomResponse(id: string, response: CustomResponse): Promise<CliMutationResult>;
   addTemp(data: TempHandlerInput): Promise<CliMutationResult>;
   removeTemp(id: string): Promise<CliSessionInfo>;
   reset(): Promise<CliSessionInfo>;

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -71,10 +71,11 @@ describe("browser control bridge", () => {
       status: 202,
     };
 
-    handlerStore.getState().setHandlerCustomResponse(handler.id, customResponse);
+    const changed = getBridge().setCustomResponse(handler.id, customResponse);
     handlerStore.getState().setHandlerBehavior(handler.id, "custom response");
 
     expect(handlerStore.getState().getHandlerCustomResponse(handler.id)).toEqual(customResponse);
+    expect(changed.handler).toMatchObject({ id: handler.id, behavior: "default", customResponse });
     const result = await handler.handler.resolver({
       request: new Request("http://localhost/custom"),
       requestId: "1",

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -162,6 +162,11 @@ const registerBrowserControlBridge = () => {
       handlerStore.getState().setHandlerBehavior(id, behavior);
       return { ...describeBrowserSession(), handler: toSerializable(requireHandler(id)) };
     },
+    setCustomResponse: (id, response) => {
+      requireHandler(id);
+      handlerStore.getState().setHandlerCustomResponse(id, response);
+      return { ...describeBrowserSession(), handler: toSerializable(requireHandler(id)) };
+    },
     addTemp: (data) => {
       handlerStore.getState().addTempHandler({ data: tempHandlerSchema.parse(data) });
       const id = JSON.stringify({ path: data.path, method: data.method });

--- a/packages/core/src/node/snapshot/mutations.ts
+++ b/packages/core/src/node/snapshot/mutations.ts
@@ -1,5 +1,5 @@
 import { getRowId } from "../../shared/utils/store";
-import { HttpHandlerBehavior, TempHandlerInput } from "../../shared/types";
+import { CustomResponse, HttpHandlerBehavior, TempHandlerInput } from "../../shared/types";
 import { bumpSnapshot } from "./serialize";
 import { readSnapshotOrEmpty, withLockedMutation } from "./file";
 import { SessionSnapshot, SerializableFlattenHandler } from "./types";
@@ -28,6 +28,23 @@ export const setSnapshotBehavior = (
     return bumpSnapshot(prev, {
       flattenHandlers: prev.flattenHandlers.map((h) =>
         h.id === id ? { ...h, behavior } : h
+      ),
+    });
+  });
+
+export const setSnapshotCustomResponse = (
+  sessionPath: string,
+  id: string,
+  customResponse: CustomResponse
+): SessionSnapshot =>
+  withLockedMutation(sessionPath, (prev) => {
+    const target = prev.flattenHandlers.find((h) => h.id === id);
+    if (!target) {
+      throw new Error(`Handler not found for id: ${id}`);
+    }
+    return bumpSnapshot(prev, {
+      flattenHandlers: prev.flattenHandlers.map((h) =>
+        h.id === id ? { ...h, customResponse } : h
       ),
     });
   });

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -10,6 +10,7 @@ import {
   writeSnapshot,
   withLockedMutation,
   setSnapshotBehavior,
+  setSnapshotCustomResponse,
   addSnapshotTempHandler,
   resolveSessionPath,
   writeSessionPointer,
@@ -86,6 +87,22 @@ describe("snapshot file protocol", () => {
     );
     expect(next.revision).toBe(2);
     expect(next.flattenHandlers[0]?.behavior).toBe(HttpHandlerBehavior.DELAY);
+  });
+
+  it("stores a custom response without changing behavior", () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    writeSnapshot(sessionPath, bumpSnapshot(createEmptySnapshot(), {
+      flattenHandlers: [{ id: "a", path: "/api", method: HttpMethod.GET, behavior: HttpHandlerBehavior.DEFAULT, type: "default" }],
+    }));
+
+    const next = setSnapshotCustomResponse(sessionPath, "a", {
+      status: 201,
+      body: "created",
+      headers: { "X-Created": "yes" },
+    });
+
+    expect(next).toMatchObject({ revision: 2, flattenHandlers: [{ behavior: HttpHandlerBehavior.DEFAULT, customResponse: { status: 201, body: "created" } }] });
   });
 
   it("adds temp handlers with tempInput", () => {

--- a/packages/core/src/shared/controlProtocol.ts
+++ b/packages/core/src/shared/controlProtocol.ts
@@ -1,9 +1,9 @@
-import { HttpHandlerBehavior } from "./types";
+import { CustomResponse, HttpHandlerBehavior } from "./types";
 import type { PersistedFlattenHandler, TempHandlerInput } from "./types";
 
 /** Global property used by a CDP client to discover a configured browser session. */
 export const BROWSER_CONTROL_KEY = "__MSW_DEV_TOOL_CONTROL__";
-export const BROWSER_CONTROL_PROTOCOL_VERSION = 1;
+export const BROWSER_CONTROL_PROTOCOL_VERSION = 2;
 
 export type BrowserControlSessionInfo = {
   revision: number;
@@ -20,6 +20,7 @@ export type BrowserControlBridge = {
   list: () => PersistedFlattenHandler[];
   get: (id: string) => PersistedFlattenHandler | undefined;
   setBehavior: (id: string, behavior: HttpHandlerBehavior) => BrowserControlMutationResult;
+  setCustomResponse: (id: string, response: CustomResponse) => BrowserControlMutationResult;
   addTemp: (data: TempHandlerInput) => BrowserControlMutationResult;
   removeTemp: (id: string) => BrowserControlSessionInfo;
   reset: () => BrowserControlSessionInfo;

--- a/packages/node-cli/src/cli/session.ts
+++ b/packages/node-cli/src/cli/session.ts
@@ -6,8 +6,9 @@ import {
   removeSnapshotTempHandler,
   requestSnapshotReset,
   setSnapshotBehavior,
+  setSnapshotCustomResponse,
 } from "@msw-dev-tool/core/node/internal";
-import { CliHandler, CliSession } from "@msw-dev-tool/cli-core";
+import { CliSession } from "@msw-dev-tool/cli-core";
 
 const POST_WRITE_SETTLE_MS = 300;
 const settleAfterWrite = () => new Promise<void>((resolve) => setTimeout(resolve, POST_WRITE_SETTLE_MS));
@@ -21,21 +22,28 @@ const toInfo = (snapshot: { revision: number; pendingReset?: boolean; flattenHan
 export class FileSnapshotCliSession implements CliSession {
   public constructor(private readonly sessionPath: string) {}
   public async describe() { return toInfo(readSessionSnapshot(this.sessionPath)); }
-  public async list() { return listSnapshotHandlers(this.sessionPath) as CliHandler[]; }
-  public async get(id: string) { return getSnapshotHandler(this.sessionPath, id) as CliHandler | undefined; }
+  public async list() { return listSnapshotHandlers(this.sessionPath); }
+  public async get(id: string) { return getSnapshotHandler(this.sessionPath, id); }
   public async setBehavior(id: string, behavior: Parameters<typeof setSnapshotBehavior>[2]) {
     const snapshot = setSnapshotBehavior(this.sessionPath, id, behavior);
     await settleAfterWrite();
     const handler = snapshot.flattenHandlers.find((entry) => entry.id === id);
     if (!handler) throw new Error(`Handler not found for id: ${id}`);
-    return { ...toInfo(snapshot), handler: handler as CliHandler };
+    return { ...toInfo(snapshot), handler };
+  }
+  public async setCustomResponse(id: string, response: Parameters<typeof setSnapshotCustomResponse>[2]) {
+    const snapshot = setSnapshotCustomResponse(this.sessionPath, id, response);
+    await settleAfterWrite();
+    const handler = snapshot.flattenHandlers.find((entry) => entry.id === id);
+    if (!handler) throw new Error(`Handler not found for id: ${id}`);
+    return { ...toInfo(snapshot), handler };
   }
   public async addTemp(data: Parameters<typeof addSnapshotTempHandler>[1]) {
     const snapshot = addSnapshotTempHandler(this.sessionPath, data);
     await settleAfterWrite();
     const handler = snapshot.flattenHandlers.at(-1);
     if (!handler) throw new Error("Temporary handler was not added");
-    return { ...toInfo(snapshot), handler: handler as CliHandler };
+    return { ...toInfo(snapshot), handler };
   }
   public async removeTemp(id: string) {
     const snapshot = removeSnapshotTempHandler(this.sessionPath, id);

--- a/packages/node-cli/src/run.test.ts
+++ b/packages/node-cli/src/run.test.ts
@@ -84,6 +84,31 @@ describe("node-cli", () => {
     expect(payload.revision).toBe(1);
   });
 
+  it("stores a custom response without changing behavior", async () => {
+    const sessionPath = createSessionFile();
+    const id = JSON.stringify({ path: "/api/items", method: "get" });
+    vi.useFakeTimers();
+    const payload = await runWithJsonOutput([
+      "--session",
+      sessionPath,
+      "set-custom-response",
+      id,
+      "--json",
+      '{"status":201,"body":"created","headers":{"X-Created":"yes"}}',
+    ], true);
+    vi.useRealTimers();
+
+    expect(payload).toMatchObject({
+      ok: true,
+      revision: 1,
+      handler: {
+        id,
+        behavior: "default",
+        customResponse: { status: 201, body: "created", headers: { "X-Created": "yes" } },
+      },
+    });
+  });
+
   it("reports session metadata and returns a handler by id", async () => {
     const sessionPath = createSessionFile();
     const id = JSON.stringify({ path: "/api/items", method: "get" });
@@ -142,6 +167,9 @@ describe("node-cli", () => {
     await expect(
       runCli(["--session", sessionPath, "set-behavior", "missing", "unknown"])
     ).rejects.toThrow(/Unknown behavior/);
+    await expect(
+      runCli(["--session", sessionPath, "set-custom-response", "missing", "--json", "{"])
+    ).rejects.toThrow("Custom response must be valid JSON");
     await expect(
       runCli(["--session", sessionPath, "add-temp", "--json", "{"])
     ).rejects.toThrow(SyntaxError);

--- a/packages/node-cli/src/run.ts
+++ b/packages/node-cli/src/run.ts
@@ -22,7 +22,11 @@ the session after a development-server/HMR reload.
 Examples:
   msw-dev-tool list
   msw-dev-tool set-behavior '{"path":"/api","method":"get"}' delay
+  msw-dev-tool set-custom-response '{"path":"/api","method":"get"}' --json '{"status":201,"body":"created"}'
   msw-dev-tool add-temp --json '{"path":"/api/tmp","method":"get","contentType":"application/json","status":"200","response":"{\\"ok\\":true}"}'
+
+set-custom-response stores response data only. Run set-behavior <id> "custom response"
+to apply it.
 `;
 
 export const runCli = async (argv: string[]): Promise<void> => {


### PR DESCRIPTION
## Abstract
Add Node and Browser CLI support for storing handler-level custom response configuration.

## Issues
N/A

## Description
- Add `set-custom-response <id> --json <customResponseJson>` to the shared CLI command set.
- Keep response configuration separate from behavior selection.
- Add Node snapshot persistence and Browser CDP bridge support.
- Return `customResponse` from CLI handler results.
- Bump the browser control protocol to version 2.
- Add minor changesets for core and all affected CLI packages.

## Additional Context
Validated with unit tests, Node fetch E2E, and Chrome CDP E2E. The browser E2E confirms that response configuration alone keeps the original 200 response, while selecting `custom response` returns the configured 201 status, body, and response header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `set-custom-response` commands for Node and browser CLI sessions.
  * Store custom response status, body, and headers for a handler.
  * Apply stored response data separately through the behavior-setting command.
  * Added support for custom-response updates through browser sessions and persisted snapshots.

* **Documentation**
  * Updated CLI usage examples and guidance for storing and applying custom responses.

* **Bug Fixes**
  * Invalid custom-response JSON now produces a clear validation error.
  * Handler behavior remains unchanged until the stored response is explicitly applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->