### PR TITLE
fix: isolate Node sessions by PID

### DIFF
--- a/.changeset/friendly-pandas-switch.md
+++ b/.changeset/friendly-pandas-switch.md
@@ -1,0 +1,6 @@
+---
+"@msw-dev-tool/core": patch
+"@msw-dev-tool/node-cli": patch
+---
+
+Store Node sessions in cwd-scoped PID snapshot files and add PID-based CLI selection.

--- a/packages/cli-core/src/args.ts
+++ b/packages/cli-core/src/args.ts
@@ -1,6 +1,6 @@
 import type { ParsedArgs } from "./types";
 
-const valueFlags = new Set(["json", "session", "cdp-url", "target"]);
+const valueFlags = new Set(["json", "pid", "cdp-url", "target"]);
 
 export const parseArgs = (argv: string[]): ParsedArgs => {
   const flags: Record<string, string | boolean> = {};

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,4 +33,13 @@ const server = await setupDevToolServer(...handlers);
 server.listen();
 ```
 
-Node sessions persist handler state to a temp **snapshot file** (same mental model as browser `sessionStorage`). AI agents can control the session with [`@msw-dev-tool/node-cli`](../node-cli).
+Node sessions persist handler state to `.msw-dev-tool/sessions/<pid>.json` in the
+directory from which the server starts. The snapshot uses the same `{ revision,
+state }` envelope as browser storage and records the owning process PID.
+
+Multiple Node processes started from the same directory each receive their own
+PID-named session file. A normal `dispose()` or process exit removes only that
+process's snapshot and lock. Crash leftovers are intentionally retained so they
+can be inspected or removed manually; starting a process that reuses that PID
+replaces its old artifacts. AI agents can control a session with
+[`@msw-dev-tool/node-cli`](../node-cli).

--- a/packages/core/src/node/handlerStore.test.ts
+++ b/packages/core/src/node/handlerStore.test.ts
@@ -5,7 +5,6 @@ import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   nodeHandlerStore,
-  SESSION_ENV_KEY,
   readSnapshot,
   setSnapshotBehavior,
   addSnapshotTempHandler,
@@ -17,14 +16,16 @@ import {
   HttpMethod,
   MimeType,
   StringHttpStatusCode,
+  getSessionPathForPid,
 } from "./internal";
 import { setupDevToolServer } from "./index";
 
 const tempDirs: string[] = [];
+const originalCwd = process.cwd();
 
 afterEach(() => {
   disposeNodeSession();
-  delete process.env[SESSION_ENV_KEY];
+  process.chdir(originalCwd);
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -33,8 +34,8 @@ afterEach(() => {
 const makeSession = () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msw-node-store-"));
   tempDirs.push(dir);
-  const sessionPath = path.join(dir, "session.json");
-  process.env[SESSION_ENV_KEY] = sessionPath;
+  process.chdir(dir);
+  const sessionPath = getSessionPathForPid(process.pid, dir);
   return sessionPath;
 };
 
@@ -46,11 +47,11 @@ describe("setupDevToolServer", () => {
     );
 
     expect(server).toBeTruthy();
-    expect(getNodeSessionPath()).toBe(sessionPath);
+    expect(getNodeSessionPath()).toBe(getSessionPathForPid(process.pid));
     expect(nodeHandlerStore.getState().flattenHandlers).toHaveLength(1);
 
     const snap = readSnapshot(sessionPath);
-    expect(snap?.flattenHandlers).toHaveLength(1);
+    expect(snap?.state.flattenHandlers).toHaveLength(1);
 
     const id = nodeHandlerStore.getState().flattenHandlers[0]!.id;
     setSnapshotBehavior(sessionPath, id, HttpHandlerBehavior.DELAY);
@@ -83,8 +84,8 @@ describe("setupDevToolServer", () => {
     );
 
     const seeded = readSnapshot(sessionPath);
-    expect(seeded?.flattenHandlers).toHaveLength(1);
-    expect(seeded?.flattenHandlers[0]?.behavior).toBe(
+    expect(seeded?.state.flattenHandlers).toHaveLength(1);
+    expect(seeded?.state.flattenHandlers[0]?.behavior).toBe(
       HttpHandlerBehavior.DEFAULT
     );
 
@@ -94,7 +95,7 @@ describe("setupDevToolServer", () => {
     expect(nodeHandlerStore.getState().getHandlerBehavior(id)).toBe(
       HttpHandlerBehavior.DISABLE
     );
-    expect(readSnapshot(sessionPath)?.flattenHandlers[0]?.behavior).toBe(
+    expect(readSnapshot(sessionPath)?.state.flattenHandlers[0]?.behavior).toBe(
       HttpHandlerBehavior.DEFAULT
     );
   });
@@ -125,6 +126,6 @@ describe("setupDevToolServer", () => {
     expect(
       nodeHandlerStore.getState().flattenHandlers.every((h) => h.type === "default")
     ).toBe(true);
-    expect(readSnapshot(sessionPath)?.pendingReset).toBeUndefined();
+    expect(readSnapshot(sessionPath)?.state.pendingReset).toBeUndefined();
   });
 });

--- a/packages/core/src/node/snapshot/apply.ts
+++ b/packages/core/src/node/snapshot/apply.ts
@@ -27,11 +27,11 @@ export const applySnapshotToRuntime = (args: {
 }): FlattenHandler[] => {
   const { runtime, current, snapshot } = args;
   const currentById = new Map(current.map((h) => [h.id, h]));
-  const snapshotIds = new Set(snapshot.flattenHandlers.map((h) => h.id));
+  const snapshotIds = new Set(snapshot.state.flattenHandlers.map((h) => h.id));
 
   const seed: FlattenHandlerSeed[] = [];
 
-  for (const entry of snapshot.flattenHandlers) {
+  for (const entry of snapshot.state.flattenHandlers) {
     if (entry.type === "temp") {
       seed.push(serializableTempToSeed(entry));
       continue;
@@ -54,10 +54,10 @@ export const applySnapshotToRuntime = (args: {
   }
 
   const lookupBehavior = (id: string) =>
-    snapshot.flattenHandlers.find((h) => h.id === id)?.behavior ??
+    snapshot.state.flattenHandlers.find((h) => h.id === id)?.behavior ??
     findHandlerBehavior(current, id);
   const lookupCustomResponse = (id: string) =>
-    snapshot.flattenHandlers.find((h) => h.id === id)?.customResponse;
+    snapshot.state.flattenHandlers.find((h) => h.id === id)?.customResponse;
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const seedAsHandlers = seed as FlattenHandler[];
@@ -67,7 +67,7 @@ export const applySnapshotToRuntime = (args: {
     lookupBehavior,
     lookupCustomResponse
   ).map((h) => {
-      const fromSnap = snapshot.flattenHandlers.find((s) => s.id === h.id);
+      const fromSnap = snapshot.state.flattenHandlers.find((s) => s.id === h.id);
       return fromSnap
         ? {
             ...h,
@@ -78,7 +78,7 @@ export const applySnapshotToRuntime = (args: {
     });
 
   const tempsChanged =
-    tempIdsSignature(current) !== tempIdsSignature(snapshot.flattenHandlers);
+    tempIdsSignature(current) !== tempIdsSignature(snapshot.state.flattenHandlers);
 
   if (tempsChanged) {
     runtime.resetHandlers();

--- a/packages/core/src/node/snapshot/controller.test.ts
+++ b/packages/core/src/node/snapshot/controller.test.ts
@@ -6,14 +6,16 @@ import { FlattenHandler, HttpHandlerBehavior, HttpMethod } from "../../shared/ty
 import { readSnapshot, writeSnapshot } from "./file";
 import { bumpSnapshot } from "./serialize";
 import { SessionController } from "./controller";
-import { SESSION_ENV_KEY } from "./types";
+import { getSessionPathForPid } from "./sessionPath";
 
 const tempDirs: string[] = [];
 
+const originalCwd = process.cwd();
 const createTempSessionPath = () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msw-session-controller-"));
   tempDirs.push(dir);
-  return path.join(dir, "session.json");
+  process.chdir(dir);
+  return getSessionPathForPid(process.pid, dir);
 };
 
 const createFlattenHandler = (): FlattenHandler => ({
@@ -27,7 +29,7 @@ const createFlattenHandler = (): FlattenHandler => ({
 });
 
 afterEach(() => {
-  delete process.env[SESSION_ENV_KEY];
+  process.chdir(originalCwd);
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -36,7 +38,6 @@ afterEach(() => {
 describe("SessionController", () => {
   it("seeds a session and applies each newer non-reset snapshot once", () => {
     const sessionPath = createTempSessionPath();
-    process.env[SESSION_ENV_KEY] = sessionPath;
     const onSnapshot = vi.fn();
     const controller = new SessionController({
       onSnapshot,
@@ -46,10 +47,10 @@ describe("SessionController", () => {
     controller.start([createFlattenHandler()]);
     const seeded = readSnapshot(sessionPath)!;
     expect(seeded.revision).toBe(1);
-    expect(seeded.flattenHandlers).toHaveLength(1);
+    expect(seeded.state.flattenHandlers).toHaveLength(1);
 
     const next = bumpSnapshot(seeded, {
-      flattenHandlers: seeded.flattenHandlers.map((handler) => ({
+      flattenHandlers: seeded.state.flattenHandlers.map((handler) => ({
         ...handler,
         behavior: HttpHandlerBehavior.DELAY,
       })),
@@ -66,7 +67,6 @@ describe("SessionController", () => {
 
   it("acknowledges reset and removes session artifacts on dispose", () => {
     const sessionPath = createTempSessionPath();
-    process.env[SESSION_ENV_KEY] = sessionPath;
     const onReset = vi.fn(() => [createFlattenHandler()]);
     const controller = new SessionController({ onSnapshot: vi.fn(), onReset });
 
@@ -79,7 +79,7 @@ describe("SessionController", () => {
     controller.sync();
 
     expect(onReset).toHaveBeenCalledTimes(1);
-    expect(readSnapshot(sessionPath)?.pendingReset).toBeUndefined();
+    expect(readSnapshot(sessionPath)?.state.pendingReset).toBeUndefined();
     controller.dispose();
     expect(fs.existsSync(sessionPath)).toBe(false);
     expect(fs.existsSync(`${sessionPath}.lock`)).toBe(false);

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -23,6 +23,7 @@ export class SessionController {
   private watcher: fs.FSWatcher | null = null;
   private watchDebounce: ReturnType<typeof setTimeout> | null = null;
   private exitHandler: (() => void) | null = null;
+  private signalHandlers = new Map<NodeJS.Signals, () => void>();
   private cleanedUp = false;
 
   public constructor(private readonly options: SessionControllerOptions) {}
@@ -35,6 +36,9 @@ export class SessionController {
     const sessionPath = ensureSessionPath();
     this.repository = new SnapshotRepository(sessionPath);
     this.cleanedUp = false;
+    // A reused PID may have left a stale file/lock after a crash.
+    clearSessionArtifacts(sessionPath);
+
     const seeded = this.repository.mutate(() =>
       bumpSnapshot(createEmptySnapshot(), {
         flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
@@ -138,11 +142,24 @@ export class SessionController {
     if (this.exitHandler) return;
     this.exitHandler = () => this.dispose();
     process.once("exit", this.exitHandler);
+    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+      const handler = () => {
+        this.dispose();
+        // Restore Node's default signal behavior after self-only cleanup.
+        process.kill(process.pid, signal);
+      };
+      this.signalHandlers.set(signal, handler);
+      process.once(signal, handler);
+    }
   }
 
   private unregisterExitHandler(): void {
     if (!this.exitHandler) return;
     process.off("exit", this.exitHandler);
     this.exitHandler = null;
+    for (const [signal, handler] of this.signalHandlers) {
+      process.off(signal, handler);
+    }
+    this.signalHandlers.clear();
   }
 }

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -35,7 +35,6 @@ export class SessionController {
     const sessionPath = ensureSessionPath();
     this.repository = new SnapshotRepository(sessionPath);
     this.cleanedUp = false;
-
     const seeded = this.repository.mutate(() =>
       bumpSnapshot(createEmptySnapshot(), {
         flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
@@ -67,10 +66,10 @@ export class SessionController {
       return;
     }
 
-    if (snapshot.pendingReset) {
+    if (snapshot.state.pendingReset) {
       const flattenHandlers = this.options.onReset();
       const cleared = repository.mutate((previous) => {
-        if (!previous.pendingReset) return previous;
+        if (!previous.state.pendingReset) return previous;
         return bumpSnapshot(previous, {
           flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
           pendingReset: false,

--- a/packages/core/src/node/snapshot/mutations.ts
+++ b/packages/core/src/node/snapshot/mutations.ts
@@ -7,7 +7,7 @@ import { SessionSnapshot, SerializableFlattenHandler } from "./types";
 export const listSnapshotHandlers = (
   sessionPath: string
 ): SerializableFlattenHandler[] =>
-  readSnapshotOrEmpty(sessionPath).flattenHandlers;
+  readSnapshotOrEmpty(sessionPath).state.flattenHandlers;
 
 export const getSnapshotHandler = (
   sessionPath: string,
@@ -21,12 +21,12 @@ export const setSnapshotBehavior = (
   behavior: HttpHandlerBehavior
 ): SessionSnapshot =>
   withLockedMutation(sessionPath, (prev) => {
-    const target = prev.flattenHandlers.find((h) => h.id === id);
+    const target = prev.state.flattenHandlers.find((h) => h.id === id);
     if (!target) {
       throw new Error(`Handler not found for id: ${id}`);
     }
     return bumpSnapshot(prev, {
-      flattenHandlers: prev.flattenHandlers.map((h) =>
+      flattenHandlers: prev.state.flattenHandlers.map((h) =>
         h.id === id ? { ...h, behavior } : h
       ),
     });
@@ -38,12 +38,12 @@ export const setSnapshotCustomResponse = (
   customResponse: CustomResponse
 ): SessionSnapshot =>
   withLockedMutation(sessionPath, (prev) => {
-    const target = prev.flattenHandlers.find((h) => h.id === id);
+    const target = prev.state.flattenHandlers.find((h) => h.id === id);
     if (!target) {
       throw new Error(`Handler not found for id: ${id}`);
     }
     return bumpSnapshot(prev, {
-      flattenHandlers: prev.flattenHandlers.map((h) =>
+      flattenHandlers: prev.state.flattenHandlers.map((h) =>
         h.id === id ? { ...h, customResponse } : h
       ),
     });
@@ -55,7 +55,7 @@ export const addSnapshotTempHandler = (
 ): SessionSnapshot =>
   withLockedMutation(sessionPath, (prev) => {
     const id = getRowId({ path: data.path, method: data.method });
-    if (prev.flattenHandlers.some((h) => h.id === id)) {
+    if (prev.state.flattenHandlers.some((h) => h.id === id)) {
       throw new Error(`Duplicate handler id: ${id}. Change method or path.`);
     }
     const entry: SerializableFlattenHandler = {
@@ -67,7 +67,7 @@ export const addSnapshotTempHandler = (
       tempInput: data,
     };
     return bumpSnapshot(prev, {
-      flattenHandlers: [...prev.flattenHandlers, entry],
+      flattenHandlers: [...prev.state.flattenHandlers, entry],
     });
   });
 
@@ -76,7 +76,7 @@ export const removeSnapshotTempHandler = (
   id: string
 ): SessionSnapshot =>
   withLockedMutation(sessionPath, (prev) => {
-    const target = prev.flattenHandlers.find((h) => h.id === id);
+    const target = prev.state.flattenHandlers.find((h) => h.id === id);
     if (!target) {
       throw new Error(`Handler not found for the given id: ${id}`);
     }
@@ -86,14 +86,14 @@ export const removeSnapshotTempHandler = (
       );
     }
     return bumpSnapshot(prev, {
-      flattenHandlers: prev.flattenHandlers.filter((h) => h.id !== id),
+      flattenHandlers: prev.state.flattenHandlers.filter((h) => h.id !== id),
     });
   });
 
 export const requestSnapshotReset = (sessionPath: string): SessionSnapshot =>
   withLockedMutation(sessionPath, (prev) =>
     bumpSnapshot(prev, {
-      flattenHandlers: prev.flattenHandlers,
+      flattenHandlers: prev.state.flattenHandlers,
       pendingReset: true,
     })
   );

--- a/packages/core/src/node/snapshot/serialize.ts
+++ b/packages/core/src/node/snapshot/serialize.ts
@@ -8,23 +8,25 @@ export const toSerializableFlattenHandlers = (
 
 export const createEmptySnapshot = (revision = 0): SessionSnapshot => ({
   revision,
-  flattenHandlers: [],
+  state: { flattenHandlers: [] },
 });
 
 export const bumpSnapshot = (
   prev: SessionSnapshot,
-  next: Partial<Pick<SessionSnapshot, "flattenHandlers" | "pendingReset">>
+  next: Partial<SessionSnapshot["state"]>
 ): SessionSnapshot => {
   const pendingReset =
     next.pendingReset === true
       ? true
       : next.pendingReset === false
         ? false
-        : Boolean(prev.pendingReset);
+      : Boolean(prev.state.pendingReset);
 
   return {
     revision: prev.revision + 1,
-    flattenHandlers: next.flattenHandlers ?? prev.flattenHandlers,
-    ...(pendingReset ? { pendingReset: true } : {}),
+    state: {
+      flattenHandlers: next.flattenHandlers ?? prev.state.flattenHandlers,
+      ...(pendingReset ? { pendingReset: true } : {}),
+    },
   };
 };

--- a/packages/core/src/node/snapshot/serialize.ts
+++ b/packages/core/src/node/snapshot/serialize.ts
@@ -9,6 +9,7 @@ export const toSerializableFlattenHandlers = (
 export const createEmptySnapshot = (revision = 0): SessionSnapshot => ({
   revision,
   state: { flattenHandlers: [] },
+  owner: { pid: process.pid },
 });
 
 export const bumpSnapshot = (
@@ -28,5 +29,6 @@ export const bumpSnapshot = (
       flattenHandlers: next.flattenHandlers ?? prev.state.flattenHandlers,
       ...(pendingReset ? { pendingReset: true } : {}),
     },
+    owner: prev.owner,
   };
 };

--- a/packages/core/src/node/snapshot/sessionPath.ts
+++ b/packages/core/src/node/snapshot/sessionPath.ts
@@ -1,73 +1,30 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import {
-  SESSION_ENV_KEY,
-  SESSION_POINTER_DIR,
-  SESSION_POINTER_FILE,
-} from "./types";
+import { SESSION_DIR, SESSIONS_DIR } from "./types";
 
-export const getSessionPointerPath = (cwd = process.cwd()) =>
-  path.join(cwd, SESSION_POINTER_DIR, SESSION_POINTER_FILE);
+export const getSessionsDirectory = (cwd = process.cwd()) =>
+  path.join(cwd, SESSION_DIR, SESSIONS_DIR);
 
-export const resolveSessionPath = (cwd = process.cwd()): string | null => {
-  const fromEnv = process.env[SESSION_ENV_KEY];
-  if (fromEnv && fromEnv.trim()) {
-    return path.resolve(fromEnv.trim());
-  }
+export const getSessionPathForPid = (pid: number, cwd = process.cwd()) =>
+  path.join(getSessionsDirectory(cwd), `${pid}.json`);
 
-  const pointerPath = getSessionPointerPath(cwd);
-  if (!fs.existsSync(pointerPath)) return null;
-
-  const pointed = fs.readFileSync(pointerPath, "utf8").trim();
-  if (!pointed) {
-    throw new Error(`Session pointer is empty: ${pointerPath}`);
-  }
-  return path.resolve(pointed);
+export const listSessionPids = (cwd = process.cwd()): number[] => {
+  const dir = getSessionsDirectory(cwd);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .map((file) => /^([0-9]+)\.json$/.exec(file)?.[1])
+    .filter((pid): pid is string => Boolean(pid))
+    .map(Number)
+    .sort((a, b) => a - b);
 };
 
-export const writeSessionPointer = (
-  sessionPath: string,
-  cwd = process.cwd()
-) => {
-  const dir = path.join(cwd, SESSION_POINTER_DIR);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(getSessionPointerPath(cwd), `${sessionPath}\n`, "utf8");
-};
-
-export const createSessionFilePath = () => {
-  const fileName = `msw-dev-tool-${process.pid}-${Math.random()
-    .toString(36)
-    .slice(2, 10)}.json`;
-  return path.join(os.tmpdir(), fileName);
-};
-
-export const ensureSessionPath = (cwd = process.cwd()): string => {
-  const existing = resolveSessionPath(cwd);
-  if (existing) {
-    const dir = path.dirname(existing);
-    fs.mkdirSync(dir, { recursive: true });
-    return existing;
-  }
-
-  const sessionPath = createSessionFilePath();
-  writeSessionPointer(sessionPath, cwd);
-  process.env[SESSION_ENV_KEY] = sessionPath;
+export const ensureSessionPath = (cwd = process.cwd(), pid = process.pid): string => {
+  const sessionPath = getSessionPathForPid(pid, cwd);
+  fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
   return sessionPath;
 };
 
-export const clearSessionArtifacts = (
-  sessionPath: string,
-  cwd = process.cwd()
-) => {
+export const clearSessionArtifacts = (sessionPath: string) => {
   fs.rmSync(sessionPath, { force: true });
   fs.rmSync(`${sessionPath}.lock`, { force: true });
-
-  const pointerPath = getSessionPointerPath(cwd);
-  if (!fs.existsSync(pointerPath)) return;
-
-  const pointed = fs.readFileSync(pointerPath, "utf8").trim();
-  if (path.resolve(pointed) === path.resolve(sessionPath)) {
-    fs.rmSync(pointerPath, { force: true });
-  }
 };

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -12,11 +12,9 @@ import {
   setSnapshotBehavior,
   setSnapshotCustomResponse,
   addSnapshotTempHandler,
-  resolveSessionPath,
-  writeSessionPointer,
-  getSessionPointerPath,
+  getSessionPathForPid,
+  listSessionPids,
   applySnapshotToRuntime,
-  SESSION_ENV_KEY,
 } from "./index";
 import {
   HttpHandlerBehavior,
@@ -37,7 +35,6 @@ const makeTempDir = () => {
 };
 
 afterEach(() => {
-  delete process.env[SESSION_ENV_KEY];
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -86,7 +83,7 @@ describe("snapshot file protocol", () => {
       HttpHandlerBehavior.DELAY
     );
     expect(next.revision).toBe(2);
-    expect(next.flattenHandlers[0]?.behavior).toBe(HttpHandlerBehavior.DELAY);
+    expect(next.state.flattenHandlers[0]?.behavior).toBe(HttpHandlerBehavior.DELAY);
   });
 
   it("stores a custom response without changing behavior", () => {
@@ -102,7 +99,7 @@ describe("snapshot file protocol", () => {
       headers: { "X-Created": "yes" },
     });
 
-    expect(next).toMatchObject({ revision: 2, flattenHandlers: [{ behavior: HttpHandlerBehavior.DEFAULT, customResponse: { status: 201, body: "created" } }] });
+    expect(next).toMatchObject({ revision: 2, state: { flattenHandlers: [{ behavior: HttpHandlerBehavior.DEFAULT, customResponse: { status: 201, body: "created" } }] } });
   });
 
   it("adds temp handlers with tempInput", () => {
@@ -118,21 +115,17 @@ describe("snapshot file protocol", () => {
       response: '{"ok":true}',
     });
 
-    expect(next.flattenHandlers).toHaveLength(1);
-    expect(next.flattenHandlers[0]?.type).toBe("temp");
-    expect(next.flattenHandlers[0]?.tempInput?.path).toBe("/api/tmp");
+    expect(next.state.flattenHandlers).toHaveLength(1);
+    expect(next.state.flattenHandlers[0]?.type).toBe("temp");
+    expect(next.state.flattenHandlers[0]?.tempInput?.path).toBe("/api/tmp");
   });
 
-  it("resolves session path from env then pointer", () => {
+  it("uses PID-named session files in the caller cwd", () => {
     const dir = makeTempDir();
-    const sessionPath = path.join(dir, "env-session.json");
-    process.env[SESSION_ENV_KEY] = sessionPath;
-    expect(resolveSessionPath(dir)).toBe(path.resolve(sessionPath));
-
-    delete process.env[SESSION_ENV_KEY];
-    const pointed = path.join(dir, "pointed.json");
-    writeSessionPointer(pointed, dir);
-    expect(resolveSessionPath(dir)).toBe(path.resolve(pointed));
+    const sessionPath = getSessionPathForPid(4182, dir);
+    writeSnapshot(sessionPath, createEmptySnapshot());
+    expect(sessionPath).toBe(path.join(dir, ".msw-dev-tool", "sessions", "4182.json"));
+    expect(listSessionPids(dir)).toEqual([4182]);
   });
 
   it("applies sequential locked mutations without lost updates", () => {
@@ -145,7 +138,7 @@ describe("snapshot file protocol", () => {
       withLockedMutation(sessionPath, (prev) =>
         bumpSnapshot(prev, {
           flattenHandlers: [
-            ...prev.flattenHandlers,
+            ...prev.state.flattenHandlers,
             {
               id: `h-${i}`,
               path: `/h-${i}`,
@@ -160,8 +153,8 @@ describe("snapshot file protocol", () => {
 
     const final = readSnapshot(sessionPath);
     expect(final?.revision).toBe(writerCount);
-    expect(final?.flattenHandlers).toHaveLength(writerCount);
-    expect(final?.flattenHandlers.map((h) => h.id).sort()).toEqual(
+    expect(final?.state.flattenHandlers).toHaveLength(writerCount);
+    expect(final?.state.flattenHandlers.map((h) => h.id).sort()).toEqual(
       Array.from({ length: writerCount }, (_, i) => `h-${i}`).sort()
     );
   });
@@ -204,8 +197,10 @@ try {
   const prev = JSON.parse(fs.readFileSync(sessionPath, "utf8"));
   const next = {
     revision: prev.revision + 1,
-    flattenHandlers: [
-      ...prev.flattenHandlers,
+    state: {
+      ...prev.state,
+      flattenHandlers: [
+      ...prev.state.flattenHandlers,
       {
         id: handlerId,
         path: "/" + handlerId,
@@ -213,7 +208,9 @@ try {
         behavior: "default",
         type: "default",
       },
-    ],
+      ],
+    },
+    owner: prev.owner,
   };
   const tmpPath = sessionPath + "." + process.pid + "." + Date.now() + ".tmp";
   fs.writeFileSync(tmpPath, JSON.stringify(next, null, 2) + "\\n", "utf8");
@@ -249,8 +246,8 @@ try {
 
     const final = readSnapshot(sessionPath);
     expect(final?.revision).toBe(writerCount);
-    expect(final?.flattenHandlers).toHaveLength(writerCount);
-    expect(final?.flattenHandlers.map((h) => h.id).sort()).toEqual(
+    expect(final?.state.flattenHandlers).toHaveLength(writerCount);
+    expect(final?.state.flattenHandlers.map((h) => h.id).sort()).toEqual(
       Array.from({ length: writerCount }, (_, i) => `p-${i}`).sort()
     );
   });
@@ -262,19 +259,12 @@ try {
     expect(() => readSnapshot(sessionPath)).toThrow(/Invalid JSON/);
   });
 
-  it("throws on empty session pointer", () => {
-    const dir = makeTempDir();
-    writeSessionPointer("", dir);
-    fs.writeFileSync(getSessionPointerPath(dir), "\n", "utf8");
-    expect(() => resolveSessionPath(dir)).toThrow(/Session pointer is empty/);
-  });
-
   it("preserves pendingReset across unrelated bumps", () => {
     const withReset = bumpSnapshot(createEmptySnapshot(), {
       flattenHandlers: [],
       pendingReset: true,
     });
-    expect(withReset.pendingReset).toBe(true);
+    expect(withReset.state.pendingReset).toBe(true);
 
     const preserved = bumpSnapshot(withReset, {
       flattenHandlers: [
@@ -287,13 +277,13 @@ try {
         },
       ],
     });
-    expect(preserved.pendingReset).toBe(true);
+    expect(preserved.state.pendingReset).toBe(true);
 
     const cleared = bumpSnapshot(preserved, {
-      flattenHandlers: preserved.flattenHandlers,
+      flattenHandlers: preserved.state.flattenHandlers,
       pendingReset: false,
     });
-    expect(cleared.pendingReset).toBeUndefined();
+    expect(cleared.state.pendingReset).toBeUndefined();
   });
 
   it("preserves current default handlers missing from snapshot", () => {
@@ -332,7 +322,7 @@ try {
       current,
       snapshot: {
         revision: 2,
-        flattenHandlers: [
+        state: { flattenHandlers: [
           {
             id: "a",
             path: "/a",
@@ -345,7 +335,8 @@ try {
               status: 202,
             },
           },
-        ],
+        ] },
+        owner: { pid: 1 },
       },
     });
 
@@ -375,7 +366,7 @@ try {
       current: [],
       snapshot: {
         revision: 1,
-        flattenHandlers: [
+        state: { flattenHandlers: [
           {
             id,
             path,
@@ -395,7 +386,8 @@ try {
               status: 202,
             },
           },
-        ],
+        ] },
+        owner: { pid: 1 },
       },
     });
 

--- a/packages/core/src/node/snapshot/types.ts
+++ b/packages/core/src/node/snapshot/types.ts
@@ -19,8 +19,10 @@ export const serializableFlattenHandlerSchema = z.object({
 
 export const sessionSnapshotSchema = z.object({
   revision: z.number(),
-  flattenHandlers: z.array(serializableFlattenHandlerSchema),
-  pendingReset: z.boolean().optional(),
+  state: z.object({
+    flattenHandlers: z.array(serializableFlattenHandlerSchema),
+    pendingReset: z.boolean().optional(),
+  }),
 });
 
 export type SerializableFlattenHandler = z.infer<

--- a/packages/core/src/node/snapshot/types.ts
+++ b/packages/core/src/node/snapshot/types.ts
@@ -23,6 +23,7 @@ export const sessionSnapshotSchema = z.object({
     flattenHandlers: z.array(serializableFlattenHandlerSchema),
     pendingReset: z.boolean().optional(),
   }),
+  owner: z.object({ pid: z.number().int().nonnegative() }),
 });
 
 export type SerializableFlattenHandler = z.infer<
@@ -30,6 +31,5 @@ export type SerializableFlattenHandler = z.infer<
 >;
 export type SessionSnapshot = z.infer<typeof sessionSnapshotSchema>;
 
-export const SESSION_POINTER_DIR = ".msw-dev-tool";
-export const SESSION_POINTER_FILE = "session";
-export const SESSION_ENV_KEY = "MSW_DEV_TOOL_SESSION";
+export const SESSION_DIR = ".msw-dev-tool";
+export const SESSIONS_DIR = "sessions";

--- a/packages/docs/app/docs/(features)/node-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/node-cli/page.mdx
@@ -58,6 +58,11 @@ working directory. Use the following selection flow:
 2. Run `msw-dev-tool sessions` to list available PIDs
 3. When more than one session exists, pass `--pid <pid>` to every command
 
+Normal process shutdown removes its session snapshot. A crash can leave a stale
+PID-named file behind, so inspect the output of `msw-dev-tool sessions` and
+remove stale files from `.msw-dev-tool/sessions` before choosing a session or
+passing `--pid`.
+
 <Callout type="warning">
   After you change handler code, run `msw-dev-tool reset` so the session
   snapshot is re-seeded from the updated handlers.

--- a/packages/docs/app/docs/(features)/node-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/node-cli/page.mdx
@@ -51,11 +51,12 @@ const server = await setupDevToolServer(...handlers);
 server.listen();
 ```
 
-On setup, a session snapshot file is created. Discovery order:
+On setup, a PID-named session snapshot file is created in the app's current
+working directory. Use the following selection flow:
 
-1. `MSW_DEV_TOOL_SESSION` env
-2. `.msw-dev-tool/session` pointer in cwd
-3. Auto-created temp file + cwd pointer
+1. `.msw-dev-tool/sessions/<pid>.json` files in the current working directory
+2. Run `msw-dev-tool sessions` to list available PIDs
+3. When more than one session exists, pass `--pid <pid>` to every command
 
 <Callout type="warning">
   After you change handler code, run `msw-dev-tool reset` so the session
@@ -72,16 +73,20 @@ On setup, a session snapshot file is created. Discovery order:
 All commands print JSON to stdout.
 
 ```bash copy
+msw-dev-tool sessions
+msw-dev-tool --pid 4182 session
 msw-dev-tool session
-msw-dev-tool list
-msw-dev-tool get '<handler-id>'
-msw-dev-tool set-behavior '<handler-id>' delay
-msw-dev-tool add-temp --json '{"path":"/api/tmp","method":"get","contentType":"application/json","status":"200","response":"{\"ok\":true}"}'
-msw-dev-tool remove-temp '<handler-id>'
-msw-dev-tool reset
+msw-dev-tool --pid 4182 list
+msw-dev-tool --pid 4182 get '<handler-id>'
+msw-dev-tool --pid 4182 set-behavior '<handler-id>' delay
+msw-dev-tool --pid 4182 add-temp --json '{"path":"/api/tmp","method":"get","contentType":"application/json","status":"200","response":"{\"ok\":true}"}'
+msw-dev-tool --pid 4182 remove-temp '<handler-id>'
+msw-dev-tool --pid 4182 reset
 ```
 
-Optional: `--session /path/to/snapshot.json`
+`--session` and `MSW_DEV_TOOL_SESSION` are no longer supported. Node session
+selection is cwd-scoped and PID-based. This is separate from the browser CLI,
+which continues to use `tabs` and `--target` for CDP target selection.
 
 ## Handler id
 

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -17,7 +17,7 @@ Open http://127.0.0.1:3001
 
 ## CLI (Node session)
 
-From `packages/example` (so `.msw-dev-tool/session` resolves):
+From `packages/example` (so its `.msw-dev-tool/sessions` directory resolves):
 
 ```bash
 yarn msw-dev-tool list

--- a/packages/node-cli/README.md
+++ b/packages/node-cli/README.md
@@ -20,15 +20,19 @@ pnpm add -D @msw-dev-tool/node-cli @msw-dev-tool/core msw
 
 ## Session discovery
 
-1. `--session <path>`
-2. `MSW_DEV_TOOL_SESSION` env
-3. `.msw-dev-tool/session` pointer in the current working directory
+Sessions are PID-named files in `.msw-dev-tool/sessions` under the current
+working directory. Run `msw-dev-tool sessions` to list them. Commands select a
+session automatically only when exactly one exists; when there are multiple,
+pass `--pid <pid>`. The former `--session` option and `MSW_DEV_TOOL_SESSION`
+environment variable are not supported.
 
 ## Commands
 
 All commands print JSON to stdout.
 
 ```bash
+msw-dev-tool sessions
+msw-dev-tool --pid 4182 list
 msw-dev-tool session
 msw-dev-tool list
 msw-dev-tool get '<id>'
@@ -51,8 +55,8 @@ server.listen();
 Then from another process / AI agent:
 
 ```bash
-msw-dev-tool list
-msw-dev-tool set-behavior '{"path":"/api/user","method":"get"}' "network error"
+msw-dev-tool --pid 4182 list
+msw-dev-tool --pid 4182 set-behavior '{"path":"/api/user","method":"get"}' "network error"
 ```
 
 After changing handler code, run `msw-dev-tool reset` and wait for `ok` before further commands. Writes during an in-flight reset can be discarded when the owner reseeds; the CLI settles ~300ms so `ok` usually means apply finished.

--- a/packages/node-cli/src/cli/context.ts
+++ b/packages/node-cli/src/cli/context.ts
@@ -1,29 +1,40 @@
-import { SESSION_ENV_KEY, resolveSessionPath } from "@msw-dev-tool/core/node/internal";
+import fs from "node:fs";
+import { getSessionPathForPid, listSessionPids } from "@msw-dev-tool/core/node/internal";
 import { CliCommandContext } from "@msw-dev-tool/cli-core";
 import { FileSnapshotCliSession } from "./session";
 
 export type CliContext = {
   sessionPath: string;
+  pid: number;
 };
 
-export const toCommandContext = ({ sessionPath }: CliContext): CliCommandContext => ({
+export const toCommandContext = ({ sessionPath, pid }: CliContext): CliCommandContext => ({
   session: new FileSnapshotCliSession(sessionPath),
-  metadata: { sessionPath },
+  metadata: { sessionPath, pid },
 });
 
 export const createCliContext = (
   flags: Record<string, string | boolean>
 ): CliContext => {
-  const fromFlag = flags.session;
-  if (typeof fromFlag === "string" && fromFlag.trim()) {
-    return { sessionPath: fromFlag.trim() };
+  const fromFlag = flags.pid;
+  if (typeof fromFlag === "string" && /^\d+$/.test(fromFlag)) {
+    const pid = Number(fromFlag);
+    const sessionPath = getSessionPathForPid(pid);
+    if (!fs.existsSync(sessionPath)) {
+      throw new Error(`No msw-dev-tool session found for PID ${pid} in this working directory.`);
+    }
+    return { pid, sessionPath };
   }
+  if (fromFlag !== undefined) throw new Error("--pid must be a numeric process ID");
 
-  const sessionPath = resolveSessionPath();
-  if (!sessionPath) {
+  const pids = listSessionPids();
+  if (pids.length === 0) {
     throw new Error(
-      `No msw-dev-tool session found. Start a Node process with setupDevToolServer() first, or pass --session <path> / set ${SESSION_ENV_KEY}.`
+      "No msw-dev-tool sessions found. Start a Node process with setupDevToolServer() first."
     );
   }
-  return { sessionPath };
+  if (pids.length > 1) {
+    throw new Error("Multiple msw-dev-tool sessions found. Run `msw-dev-tool sessions` and specify --pid <pid>.");
+  }
+  return { pid: pids[0]!, sessionPath: getSessionPathForPid(pids[0]!) };
 };

--- a/packages/node-cli/src/cli/session.ts
+++ b/packages/node-cli/src/cli/session.ts
@@ -12,13 +12,13 @@ import { CliSession } from "@msw-dev-tool/cli-core";
 
 const POST_WRITE_SETTLE_MS = 300;
 const settleAfterWrite = () => new Promise<void>((resolve) => setTimeout(resolve, POST_WRITE_SETTLE_MS));
-const toInfo = (snapshot: { revision: number; pendingReset?: boolean; flattenHandlers: unknown[] }) => ({
+const toInfo = (snapshot: { revision: number; state: { pendingReset?: boolean; flattenHandlers: unknown[] } }) => ({
   revision: snapshot.revision,
-  pendingReset: Boolean(snapshot.pendingReset),
-  handlerCount: snapshot.flattenHandlers.length,
+  pendingReset: Boolean(snapshot.state.pendingReset),
+  handlerCount: snapshot.state.flattenHandlers.length,
 });
 
-/** File-backed adapter. TODO: migrate the Node snapshot envelope to { revision, state }. */
+/** File-backed adapter for Node snapshot envelopes. */
 export class FileSnapshotCliSession implements CliSession {
   public constructor(private readonly sessionPath: string) {}
   public async describe() { return toInfo(readSessionSnapshot(this.sessionPath)); }
@@ -27,21 +27,21 @@ export class FileSnapshotCliSession implements CliSession {
   public async setBehavior(id: string, behavior: Parameters<typeof setSnapshotBehavior>[2]) {
     const snapshot = setSnapshotBehavior(this.sessionPath, id, behavior);
     await settleAfterWrite();
-    const handler = snapshot.flattenHandlers.find((entry) => entry.id === id);
+    const handler = snapshot.state.flattenHandlers.find((entry) => entry.id === id);
     if (!handler) throw new Error(`Handler not found for id: ${id}`);
     return { ...toInfo(snapshot), handler };
   }
   public async setCustomResponse(id: string, response: Parameters<typeof setSnapshotCustomResponse>[2]) {
     const snapshot = setSnapshotCustomResponse(this.sessionPath, id, response);
     await settleAfterWrite();
-    const handler = snapshot.flattenHandlers.find((entry) => entry.id === id);
+    const handler = snapshot.state.flattenHandlers.find((entry) => entry.id === id);
     if (!handler) throw new Error(`Handler not found for id: ${id}`);
     return { ...toInfo(snapshot), handler };
   }
   public async addTemp(data: Parameters<typeof addSnapshotTempHandler>[1]) {
     const snapshot = addSnapshotTempHandler(this.sessionPath, data);
     await settleAfterWrite();
-    const handler = snapshot.flattenHandlers.at(-1);
+    const handler = snapshot.state.flattenHandlers.at(-1);
     if (!handler) throw new Error("Temporary handler was not added");
     return { ...toInfo(snapshot), handler };
   }

--- a/packages/node-cli/src/run.test.ts
+++ b/packages/node-cli/src/run.test.ts
@@ -2,34 +2,27 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getSessionPathForPid } from "@msw-dev-tool/core/node/internal";
 import { runCli } from "../src/run";
 
 const tempDirs: string[] = [];
+const originalCwd = process.cwd();
 
-const createSessionFile = () => {
+const createSessionFile = (pid = 4182) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msw-dev-tool-cli-"));
   tempDirs.push(dir);
-  const sessionPath = path.join(dir, "session.json");
-  fs.writeFileSync(
-    sessionPath,
-    JSON.stringify(
-      {
-        revision: 0,
-        flattenHandlers: [
-          {
-            id: JSON.stringify({ path: "/api/items", method: "get" }),
-            path: "/api/items",
-            method: "get",
-            behavior: "default",
-            type: "default",
-          },
-        ],
-      },
-      null,
-      2
-    )
-  );
-  return sessionPath;
+  process.chdir(dir);
+  const sessionPath = getSessionPathForPid(pid, dir);
+  fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
+  fs.writeFileSync(sessionPath, JSON.stringify({
+    revision: 0,
+    owner: { pid },
+    state: { flattenHandlers: [{
+      id: JSON.stringify({ path: "/api/items", method: "get" }),
+      path: "/api/items", method: "get", behavior: "default", type: "default",
+    }] },
+  }));
+  return { pid, sessionPath };
 };
 
 const runWithJsonOutput = async (argv: string[], settle = false) => {
@@ -39,7 +32,6 @@ const runWithJsonOutput = async (argv: string[], settle = false) => {
     logs.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
-
   try {
     const running = runCli(argv);
     if (settle) await vi.advanceTimersByTimeAsync(300);
@@ -47,134 +39,43 @@ const runWithJsonOutput = async (argv: string[], settle = false) => {
   } finally {
     process.stdout.write = originalWrite;
   }
-
   return JSON.parse(logs.join(""));
 };
 
 afterEach(() => {
   vi.useRealTimers();
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  process.chdir(originalCwd);
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 describe("node-cli", () => {
-  it("lists handlers from a session snapshot", async () => {
-    const sessionPath = createSessionFile();
-    const payload = await runWithJsonOutput(["--session", sessionPath, "list"]);
-    expect(payload.ok).toBe(true);
-    expect(payload.handlers).toHaveLength(1);
-    expect(payload.handlers[0].path).toBe("/api/items");
+  it("lists PID sessions in the current working directory", async () => {
+    createSessionFile(4182);
+    const secondPath = getSessionPathForPid(4217);
+    fs.mkdirSync(path.dirname(secondPath), { recursive: true });
+    fs.writeFileSync(secondPath, JSON.stringify({ revision: 0, owner: { pid: 4217 }, state: { flattenHandlers: [] } }));
+    await expect(runWithJsonOutput(["sessions"])).resolves.toEqual({ ok: true, sessions: [{ pid: 4182 }, { pid: 4217 }] });
   });
 
-  it("sets behavior in the snapshot", async () => {
-    const sessionPath = createSessionFile();
+  it("automatically selects the only session and applies a mutation", async () => {
+    const { pid } = createSessionFile();
     const id = JSON.stringify({ path: "/api/items", method: "get" });
     vi.useFakeTimers();
-    const payload = await runWithJsonOutput([
-      "--session",
-      sessionPath,
-      "set-behavior",
-      id,
-      "delay",
-    ], true);
-    vi.useRealTimers();
-    expect(payload.ok).toBe(true);
-    expect(payload.handler.behavior).toBe("delay");
-    expect(payload.revision).toBe(1);
+    const payload = await runWithJsonOutput(["set-behavior", id, "delay"], true);
+    expect(payload).toMatchObject({ ok: true, pid, revision: 1, handler: { behavior: "delay" } });
   });
 
-  it("stores a custom response without changing behavior", async () => {
-    const sessionPath = createSessionFile();
-    const id = JSON.stringify({ path: "/api/items", method: "get" });
-    vi.useFakeTimers();
-    const payload = await runWithJsonOutput([
-      "--session",
-      sessionPath,
-      "set-custom-response",
-      id,
-      "--json",
-      '{"status":201,"body":"created","headers":{"X-Created":"yes"}}',
-    ], true);
-    vi.useRealTimers();
-
-    expect(payload).toMatchObject({
-      ok: true,
-      revision: 1,
-      handler: {
-        id,
-        behavior: "default",
-        customResponse: { status: 201, body: "created", headers: { "X-Created": "yes" } },
-      },
-    });
+  it("requires --pid when multiple sessions exist and selects the requested PID", async () => {
+    createSessionFile(4182);
+    const secondPath = getSessionPathForPid(4217);
+    fs.writeFileSync(secondPath, JSON.stringify({ revision: 0, owner: { pid: 4217 }, state: { flattenHandlers: [] } }));
+    await expect(runCli(["list"])).rejects.toThrow(/Multiple msw-dev-tool sessions/);
+    await expect(runWithJsonOutput(["--pid", "4217", "list"])).resolves.toMatchObject({ ok: true, pid: 4217, handlers: [] });
   });
 
-  it("reports session metadata and returns a handler by id", async () => {
-    const sessionPath = createSessionFile();
-    const id = JSON.stringify({ path: "/api/items", method: "get" });
-
-    const session = await runWithJsonOutput(["--session", sessionPath, "session"]);
-    const get = await runWithJsonOutput(["--session", sessionPath, "get", id]);
-
-    expect(session).toMatchObject({
-      ok: true,
-      sessionPath,
-      revision: 0,
-      handlerCount: 1,
-    });
-    expect(get).toMatchObject({ ok: true, sessionPath, handler: { id } });
-  });
-
-  it("adds, removes, and resets handlers through the command registry", async () => {
-    const sessionPath = createSessionFile();
-    const data = JSON.stringify({
-      path: "/api/temp",
-      method: "get",
-      contentType: "application/json",
-      status: "200",
-      response: '{"ok":true}',
-    });
-
-    vi.useFakeTimers();
-    const added = await runWithJsonOutput([
-      "--session",
-      sessionPath,
-      "add-temp",
-      "--json",
-      data,
-    ], true);
-    const tempId = added.handler.id;
-    const removed = await runWithJsonOutput([
-      "--session",
-      sessionPath,
-      "remove-temp",
-      tempId,
-    ], true);
-    const reset = await runWithJsonOutput(["--session", sessionPath, "reset"], true);
-    vi.useRealTimers();
-
-    expect(added).toMatchObject({ ok: true, handler: { type: "temp" } });
-    expect(removed).toMatchObject({ ok: true, revision: 2 });
-    expect(reset).toMatchObject({ ok: true, revision: 3, pendingReset: true });
-  });
-
-  it("rejects malformed command input before mutating the snapshot", async () => {
-    const sessionPath = createSessionFile();
-
-    await expect(runCli(["--session", sessionPath, "get"])).rejects.toThrow(
-      "Usage: get <id>"
-    );
-    await expect(
-      runCli(["--session", sessionPath, "set-behavior", "missing", "unknown"])
-    ).rejects.toThrow(/Unknown behavior/);
-    await expect(
-      runCli(["--session", sessionPath, "set-custom-response", "missing", "--json", "{"])
-    ).rejects.toThrow("Custom response must be valid JSON");
-    await expect(
-      runCli(["--session", sessionPath, "add-temp", "--json", "{"])
-    ).rejects.toThrow(SyntaxError);
-    await expect(runCli(["--session", sessionPath, "unknown-command"])).rejects.toThrow(
-      /Unknown command/
-    );
+  it("rejects malformed commands before mutating a selected session", async () => {
+    const { pid } = createSessionFile();
+    await expect(runCli(["--pid", String(pid), "get"])).rejects.toThrow("Usage: get <id>");
+    await expect(runCli(["--pid", "not-a-pid", "list"])).rejects.toThrow("--pid must be a numeric process ID");
   });
 });

--- a/packages/node-cli/src/run.ts
+++ b/packages/node-cli/src/run.ts
@@ -1,5 +1,6 @@
 import { commandUsage, findCommand, parseArgs, printJson } from "@msw-dev-tool/cli-core";
 import { createCliContext, toCommandContext } from "./cli/context";
+import { listSessionPids } from "@msw-dev-tool/core/node/internal";
 
 const usage = `msw-dev-tool — AI-oriented CLI for @msw-dev-tool/core Node sessions
 
@@ -7,10 +8,10 @@ This package is intended for AI agents to programmatically control msw-dev-tool
 via one-shot commands. It reads/writes the session snapshot file; it does not
 own the MSW SetupServer (the app that called setupDevToolServer does).
 
-Session discovery (priority):
-  1. --session <path>
-  2. MSW_DEV_TOOL_SESSION
-  3. .msw-dev-tool/session pointer in cwd
+Session discovery:
+  msw-dev-tool sessions            List PID-based sessions in this cwd
+  msw-dev-tool --pid <pid> <command>
+  When exactly one session exists, commands select it automatically.
 
 Commands:
 ${commandUsage()}
@@ -35,6 +36,11 @@ export const runCli = async (argv: string[]): Promise<void> => {
 
   if (commandName === "help" || flags.help) {
     process.stdout.write(`${usage}\n`);
+    return;
+  }
+
+  if (commandName === "sessions") {
+    printJson({ ok: true, sessions: listSessionPids().map((pid) => ({ pid })) });
     return;
   }
 


### PR DESCRIPTION
## Summary
- isolate Node snapshot files by cwd and owner PID
- add PID-based Node CLI discovery and selection
- prevent compatible core peer updates from causing major dependent releases

## Verification
- core and node-cli typechecks
- core (85) and node-cli (4) tests
- manual multi-worktree, multi-PID CLI validation
- changeset status: no major releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PID-based Node session discovery and selection.
  * Added a `sessions` command to list active session PIDs.
  * Automatically selects the only available session; multiple sessions require `--pid`.
  * Improved isolation for multiple processes and cleanup during normal shutdown.

* **Documentation**
  * Updated CLI and Node session documentation with PID-based usage and troubleshooting guidance.
  * Removed legacy `--session` and environment-variable selection instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->