### PR TITLE
fix(core): support HTTP 305 responses

### DIFF
--- a/.changeset/bright-otters-use.md
+++ b/.changeset/bright-otters-use.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": patch
+---
+
+Fix custom HTTP 305 responses to use the standard `Use Proxy` status text.

--- a/packages/core/src/shared/types/http.ts
+++ b/packages/core/src/shared/types/http.ts
@@ -1,6 +1,38 @@
 import { ValueUnion } from "./utils";
 
-export const STANDARD_HTTP_STATUS_TEXT: Readonly<Record<number, string>> = {
+/**
+ * Comment out rarely used status codes until the user requests them.
+ */
+export const HttpErrorStatusCode = {
+  // 4xx Client Error
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  //PAYMENT_REQUIRED: 402,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  METHOD_NOT_ALLOWED: 405,
+  NOT_ACCEPTABLE: 406,
+  CONFLICT: 409,
+  //GONE: 410,
+  PRECONDITION_FAILED: 412,
+  PAYLOAD_TOO_LARGE: 413,
+  UNSUPPORTED_MEDIA_TYPE: 415,
+  //RANGE_NOT_SATISFIABLE: 416,
+  TOO_MANY_REQUESTS: 429,
+
+  // 5xx Server Error
+  INTERNAL_SERVER_ERROR: 500,
+  //NOT_IMPLEMENTED: 501,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504,
+  //HTTP_VERSION_NOT_SUPPORTED: 505,
+} as const;
+
+export type HttpErrorStatusCode = ValueUnion<typeof HttpErrorStatusCode>;
+
+/** Standard reason phrases for HTTP response status codes. */
+export const STANDARD_HTTP_STATUS_TEXT: Record<number, string> = {
   200: "OK",
   201: "Created",
   202: "Accepted",
@@ -16,6 +48,7 @@ export const STANDARD_HTTP_STATUS_TEXT: Readonly<Record<number, string>> = {
   302: "Found",
   303: "See Other",
   304: "Not Modified",
+  305: "Use Proxy",
   307: "Temporary Redirect",
   308: "Permanent Redirect",
   400: "Bad Request",
@@ -59,37 +92,6 @@ export const STANDARD_HTTP_STATUS_TEXT: Readonly<Record<number, string>> = {
   510: "Not Extended",
   511: "Network Authentication Required",
 };
-
-/**
- * Comment out rarely used status codes until the user requests them.
- */
-export const HttpErrorStatusCode = {
-  // 4xx Client Error
-  BAD_REQUEST: 400,
-  UNAUTHORIZED: 401,
-  //PAYMENT_REQUIRED: 402,
-  FORBIDDEN: 403,
-  NOT_FOUND: 404,
-  METHOD_NOT_ALLOWED: 405,
-  NOT_ACCEPTABLE: 406,
-  CONFLICT: 409,
-  //GONE: 410,
-  PRECONDITION_FAILED: 412,
-  PAYLOAD_TOO_LARGE: 413,
-  UNSUPPORTED_MEDIA_TYPE: 415,
-  //RANGE_NOT_SATISFIABLE: 416,
-  TOO_MANY_REQUESTS: 429,
-
-  // 5xx Server Error
-  INTERNAL_SERVER_ERROR: 500,
-  //NOT_IMPLEMENTED: 501,
-  BAD_GATEWAY: 502,
-  SERVICE_UNAVAILABLE: 503,
-  GATEWAY_TIMEOUT: 504,
-  //HTTP_VERSION_NOT_SUPPORTED: 505,
-} as const;
-
-export type HttpErrorStatusCode = ValueUnion<typeof HttpErrorStatusCode>;
 
 export const HttpSuccessStatusCode = {
   OK: 200,

--- a/packages/core/src/shared/utils/handler.test.ts
+++ b/packages/core/src/shared/utils/handler.test.ts
@@ -134,6 +134,10 @@ describe("getHandlerResponseByBehavior", () => {
     });
   });
 
+  it("includes the 305 standard status text", () => {
+    expect(STANDARD_HTTP_STATUS_TEXT[305]).toBe("Use Proxy");
+  });
+
   it("falls back to original resolver for unknown behavior", async () => {
     const original = vi.fn(async () => HttpResponse.json({ fallback: true }));
     await getHandlerResponseByBehavior("unknown", original);


### PR DESCRIPTION
## Summary
- return the standard `Use Proxy` status text for custom HTTP 305 responses
- centralize standard HTTP status texts for reuse
- add a patch changeset for `@msw-dev-tool/core`

## Testing
- `yarn workspace @msw-dev-tool/core test src/shared/utils/handler.test.ts`
- `yarn workspace @msw-dev-tool/core typecheck`