### PR TITLE
chore(release): avoid compatible peer major bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": ["docs", "example"]
 }

--- a/packages/browser-cli/package.json
+++ b/packages/browser-cli/package.json
@@ -36,7 +36,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "@msw-dev-tool/core": "workspace:*"
+    "@msw-dev-tool/core": "workspace:^1.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/node-cli/package.json
+++ b/packages/node-cli/package.json
@@ -37,15 +37,16 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@msw-dev-tool/cli-core": "workspace:*",
-    "@msw-dev-tool/core": "workspace:*"
+    "@msw-dev-tool/cli-core": "workspace:*"
   },
   "devDependencies": {
+    "@msw-dev-tool/core": "workspace:*",
     "@types/node": "^22.13.10",
     "typescript": "^5.8.3",
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
+    "@msw-dev-tool/core": "workspace:^1.4.0",
     "msw": "^2.7.0"
   },
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@msw-dev-tool/core": "workspace:*",
+    "@msw-dev-tool/core": "workspace:^1.4.0",
     "msw": "^2.7.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,7 +1131,7 @@ __metadata:
     vitest: "npm:^4.1.10"
     ws: "npm:^8.18.0"
   peerDependencies:
-    "@msw-dev-tool/core": "workspace:*"
+    "@msw-dev-tool/core": "workspace:^1.4.0"
   bin:
     msw-dev-tool-browser: ./bin/msw-dev-tool-browser.js
   languageName: unknown
@@ -1192,6 +1192,7 @@ __metadata:
     typescript: "npm:^5.8.3"
     vitest: "npm:^4.1.10"
   peerDependencies:
+    "@msw-dev-tool/core": "workspace:^1.4.0"
     msw: ^2.7.0
   bin:
     msw-dev-tool: ./bin/msw-dev-tool.js
@@ -1230,7 +1231,7 @@ __metadata:
     typescript-eslint: "npm:^8.30.1"
     zod: "npm:^3.24.2"
   peerDependencies:
-    "@msw-dev-tool/core": "workspace:*"
+    "@msw-dev-tool/core": "workspace:^1.4.0"
     msw: ^2.7.0
     react: ^18 || ^19
     react-dom: ^18 || ^19


### PR DESCRIPTION
## Summary
- avoid compatible peer dependency updates triggering major dependent releases
- align package peer ranges and lockfile

## Verification
- to be run after PR #138 is rebased