### PR TITLE
fix(core): replace synchronous session file operations

### DIFF
--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -33,5 +33,26 @@ export default tseslint.config(
         { assertionStyle: "never" },
       ],
     },
+  },
+  {
+    files: ["src/**/*.{js,mjs,cjs,ts,tsx}"],
+    ignores: ["src/**/*.test.{js,mjs,cjs,ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "fs",
+              message: "Use node:fs/promises for asynchronous file system access.",
+            },
+            {
+              name: "node:fs",
+              message: "Use node:fs/promises for asynchronous file system access.",
+            },
+          ],
+        },
+      ],
+    },
   }
 );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "clean": "rm -rf dist && rm -rf node_modules",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "yarn build && vitest run"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
@@ -80,6 +80,7 @@
     }
   },
   "dependencies": {
+    "chokidar": "^5.0.0",
     "proper-lockfile": "^4.1.2",
     "zod": "^3.24.2"
   },

--- a/packages/core/src/node/handlerStore.test.ts
+++ b/packages/core/src/node/handlerStore.test.ts
@@ -23,8 +23,8 @@ import { setupDevToolServer } from "./index";
 const tempDirs: string[] = [];
 const originalCwd = process.cwd();
 
-afterEach(() => {
-  disposeNodeSession();
+afterEach(async () => {
+  await disposeNodeSession();
   process.chdir(originalCwd);
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -50,13 +50,13 @@ describe("setupDevToolServer", () => {
     expect(getNodeSessionPath()).toBe(getSessionPathForPid(process.pid));
     expect(nodeHandlerStore.getState().flattenHandlers).toHaveLength(1);
 
-    const snap = readSnapshot(sessionPath);
+    const snap = await readSnapshot(sessionPath);
     expect(snap?.state.flattenHandlers).toHaveLength(1);
 
     const id = nodeHandlerStore.getState().flattenHandlers[0]!.id;
-    setSnapshotBehavior(sessionPath, id, HttpHandlerBehavior.DELAY);
+    await setSnapshotBehavior(sessionPath, id, HttpHandlerBehavior.DELAY);
 
-    syncNodeSession();
+    await syncNodeSession();
 
     expect(nodeHandlerStore.getState().getHandlerBehavior(id)).toBe(
       HttpHandlerBehavior.DELAY
@@ -83,7 +83,7 @@ describe("setupDevToolServer", () => {
       http.get("/api/items", () => HttpResponse.json({ ok: true }))
     );
 
-    const seeded = readSnapshot(sessionPath);
+    const seeded = await readSnapshot(sessionPath);
     expect(seeded?.state.flattenHandlers).toHaveLength(1);
     expect(seeded?.state.flattenHandlers[0]?.behavior).toBe(
       HttpHandlerBehavior.DEFAULT
@@ -95,7 +95,7 @@ describe("setupDevToolServer", () => {
     expect(nodeHandlerStore.getState().getHandlerBehavior(id)).toBe(
       HttpHandlerBehavior.DISABLE
     );
-    expect(readSnapshot(sessionPath)?.state.flattenHandlers[0]?.behavior).toBe(
+    expect((await readSnapshot(sessionPath))?.state.flattenHandlers[0]?.behavior).toBe(
       HttpHandlerBehavior.DEFAULT
     );
   });
@@ -107,7 +107,7 @@ describe("setupDevToolServer", () => {
       http.get("/api/items", () => HttpResponse.json({ ok: true }))
     );
 
-    addSnapshotTempHandler(sessionPath, {
+    await addSnapshotTempHandler(sessionPath, {
       path: "/api/tmp",
       method: HttpMethod.GET,
       contentType: MimeType.APPLICATION_JSON,
@@ -115,17 +115,18 @@ describe("setupDevToolServer", () => {
       response: '{"ok":true}',
     });
 
-    syncNodeSession();
+    await syncNodeSession();
     expect(
       nodeHandlerStore.getState().flattenHandlers.some((h) => h.type === "temp")
     ).toBe(true);
 
-    requestSnapshotReset(sessionPath);
-    syncNodeSession();
+    await requestSnapshotReset(sessionPath);
+    await syncNodeSession();
 
     expect(
       nodeHandlerStore.getState().flattenHandlers.every((h) => h.type === "default")
     ).toBe(true);
-    expect(readSnapshot(sessionPath)?.state.pendingReset).toBeUndefined();
+    expect((await readSnapshot(sessionPath))?.state.pendingReset).toBeUndefined();
   });
+
 });

--- a/packages/core/src/node/handlerStore.ts
+++ b/packages/core/src/node/handlerStore.ts
@@ -52,21 +52,23 @@ export const setupDevToolServer = async (...handlers: Handler[]): Promise<SetupS
   });
 
   try {
-    session.start(baseStore.getState().flattenHandlers);
+    await session.start(baseStore.getState().flattenHandlers);
     activeSession = session;
     return server;
   } catch (error) {
-    session.dispose();
+    await session.dispose();
     throw error;
   }
 };
 
 /** @internal CLI/runtime integration only. */
-export const syncNodeSession = (): void => activeSession?.sync();
+export const syncNodeSession = async (): Promise<void> => {
+  await activeSession?.sync();
+};
 
 /** @internal lifecycle and test teardown only. */
-export const disposeNodeSession = (): void => {
-  activeSession?.dispose();
+export const disposeNodeSession = async (): Promise<void> => {
+  await activeSession?.dispose();
   activeSession = null;
 };
 

--- a/packages/core/src/node/snapshot/controller.test.ts
+++ b/packages/core/src/node/snapshot/controller.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 });
 
 describe("SessionController", () => {
-  it("seeds a session and applies each newer non-reset snapshot once", () => {
+  it("seeds a session and applies each newer non-reset snapshot once", async () => {
     const sessionPath = createTempSessionPath();
     const onSnapshot = vi.fn();
     const controller = new SessionController({
@@ -44,8 +44,8 @@ describe("SessionController", () => {
       onReset: () => [createFlattenHandler()],
     });
 
-    controller.start([createFlattenHandler()]);
-    const seeded = readSnapshot(sessionPath)!;
+    await controller.start([createFlattenHandler()]);
+    const seeded = (await readSnapshot(sessionPath))!;
     expect(seeded.revision).toBe(1);
     expect(seeded.state.flattenHandlers).toHaveLength(1);
 
@@ -55,32 +55,32 @@ describe("SessionController", () => {
         behavior: HttpHandlerBehavior.DELAY,
       })),
     });
-    writeSnapshot(sessionPath, next);
+    await writeSnapshot(sessionPath, next);
 
-    controller.sync();
-    controller.sync();
+    await controller.sync();
+    await controller.sync();
 
     expect(onSnapshot).toHaveBeenCalledTimes(1);
     expect(onSnapshot).toHaveBeenCalledWith(next);
-    controller.dispose();
+    await controller.dispose();
   });
 
-  it("acknowledges reset and removes session artifacts on dispose", () => {
+  it("acknowledges reset and removes session artifacts on dispose", async () => {
     const sessionPath = createTempSessionPath();
     const onReset = vi.fn(() => [createFlattenHandler()]);
     const controller = new SessionController({ onSnapshot: vi.fn(), onReset });
 
-    controller.start([createFlattenHandler()]);
-    const resetRequest = bumpSnapshot(readSnapshot(sessionPath)!, {
+    await controller.start([createFlattenHandler()]);
+    const resetRequest = bumpSnapshot((await readSnapshot(sessionPath))!, {
       pendingReset: true,
     });
-    writeSnapshot(sessionPath, resetRequest);
+    await writeSnapshot(sessionPath, resetRequest);
 
-    controller.sync();
+    await controller.sync();
 
     expect(onReset).toHaveBeenCalledTimes(1);
-    expect(readSnapshot(sessionPath)?.state.pendingReset).toBeUndefined();
-    controller.dispose();
+    expect((await readSnapshot(sessionPath))?.state.pendingReset).toBeUndefined();
+    await controller.dispose();
     expect(fs.existsSync(sessionPath)).toBe(false);
     expect(fs.existsSync(`${sessionPath}.lock`)).toBe(false);
   });

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs";
+import { FSWatcher, watch } from "chokidar";
+import fs from "node:fs/promises";
 import { FlattenHandler } from "../../shared/types";
 import { clearSessionArtifacts, ensureSessionPath } from "./sessionPath";
 import { bumpSnapshot, createEmptySnapshot, toSerializableFlattenHandlers } from "./serialize";
@@ -7,6 +8,9 @@ import { SessionSnapshot } from "./types";
 
 const DEFAULT_POLL_INTERVAL_MS = 200;
 const WATCH_DEBOUNCE_MS = 25;
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 
 export type SessionControllerOptions = {
   onSnapshot: (snapshot: SessionSnapshot) => void;
@@ -20,10 +24,11 @@ export class SessionController {
   private lastWrittenRevision = 0;
   private lastAppliedRevision = 0;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
-  private watcher: fs.FSWatcher | null = null;
+  private watcher: FSWatcher | null = null;
   private watchDebounce: ReturnType<typeof setTimeout> | null = null;
   private exitHandler: (() => void) | null = null;
   private signalHandlers = new Map<NodeJS.Signals, () => void>();
+  private syncQueue: Promise<void> = Promise.resolve();
   private cleanedUp = false;
 
   public constructor(private readonly options: SessionControllerOptions) {}
@@ -32,14 +37,14 @@ export class SessionController {
     return this.repository?.sessionPath ?? null;
   }
 
-  public start(flattenHandlers: FlattenHandler[]): void {
-    const sessionPath = ensureSessionPath();
+  public async start(flattenHandlers: FlattenHandler[]): Promise<void> {
+    const sessionPath = await ensureSessionPath();
     this.repository = new SnapshotRepository(sessionPath);
     this.cleanedUp = false;
     // A reused PID may have left a stale file/lock after a crash.
-    clearSessionArtifacts(sessionPath);
+    await clearSessionArtifacts(sessionPath);
 
-    const seeded = this.repository.mutate(() =>
+    const seeded = await this.repository.mutate(() =>
       bumpSnapshot(createEmptySnapshot(), {
         flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
       })
@@ -47,15 +52,24 @@ export class SessionController {
     this.lastWrittenRevision = seeded.revision;
     this.lastAppliedRevision = seeded.revision;
 
-    this.startWatching();
+    await this.startWatching();
     this.registerExitHandler();
   }
 
-  public sync(): void {
+  public sync(): Promise<void> {
+    this.syncQueue = this.syncQueue
+      .then(() => this.syncNow())
+      .catch((error: unknown) => {
+        console.warn("[msw-dev-tool] failed to synchronize session snapshot", error);
+      });
+    return this.syncQueue;
+  }
+
+  private async syncNow(): Promise<void> {
     const repository = this.repository;
     if (!repository) return;
 
-    const snapshot = repository.read();
+    const snapshot = await repository.read();
     if (!snapshot || snapshot.revision <= this.lastAppliedRevision) return;
 
     if (snapshot.revision === this.lastWrittenRevision) {
@@ -72,7 +86,7 @@ export class SessionController {
 
     if (snapshot.state.pendingReset) {
       const flattenHandlers = this.options.onReset();
-      const cleared = repository.mutate((previous) => {
+      const cleared = await repository.mutate((previous) => {
         if (!previous.state.pendingReset) return previous;
         return bumpSnapshot(previous, {
           flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
@@ -88,34 +102,44 @@ export class SessionController {
     this.lastAppliedRevision = snapshot.revision;
   }
 
-  public dispose(): void {
-    this.stopWatching();
+  public async dispose(): Promise<void> {
+    await this.stopWatching();
     this.unregisterExitHandler();
     const sessionPath = this.sessionPath;
     if (sessionPath && !this.cleanedUp) {
-      clearSessionArtifacts(sessionPath);
+      await clearSessionArtifacts(sessionPath);
       this.cleanedUp = true;
     }
     this.repository = null;
   }
 
-  private startWatching(): void {
+  private async startWatching(): Promise<void> {
     const repository = this.repository;
     if (!repository) return;
 
-    this.stopWatching();
-    if (!fs.existsSync(repository.sessionPath)) {
-      repository.write(createEmptySnapshot());
+    await this.stopWatching();
+    try {
+      await fs.access(repository.sessionPath);
+    } catch (error) {
+      if (!isEnoent(error)) throw error;
+      await repository.write(createEmptySnapshot());
     }
 
-    this.watcher = fs.watch(repository.sessionPath, () => this.scheduleSync());
+    this.watcher = watch(repository.sessionPath, {
+      atomic: true,
+      ignoreInitial: true,
+      persistent: false,
+    });
+    this.watcher.on("all", (event) => {
+      if (event === "add" || event === "change") this.scheduleSync();
+    });
     this.watcher.on("error", () => {
-      this.watcher?.close();
+      void this.watcher?.close();
       this.watcher = null;
     });
 
     this.pollTimer = setInterval(
-      () => this.sync(),
+      () => void this.sync(),
       this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
     );
     this.pollTimer.unref?.();
@@ -125,14 +149,14 @@ export class SessionController {
     if (this.watchDebounce) clearTimeout(this.watchDebounce);
     this.watchDebounce = setTimeout(() => {
       this.watchDebounce = null;
-      this.sync();
+      void this.sync();
     }, WATCH_DEBOUNCE_MS);
   }
 
-  private stopWatching(): void {
+  private async stopWatching(): Promise<void> {
     if (this.watchDebounce) clearTimeout(this.watchDebounce);
     this.watchDebounce = null;
-    this.watcher?.close();
+    if (this.watcher) await this.watcher.close();
     this.watcher = null;
     if (this.pollTimer) clearInterval(this.pollTimer);
     this.pollTimer = null;
@@ -140,11 +164,11 @@ export class SessionController {
 
   private registerExitHandler(): void {
     if (this.exitHandler) return;
-    this.exitHandler = () => this.dispose();
-    process.once("exit", this.exitHandler);
+    this.exitHandler = () => void this.dispose();
+    process.once("beforeExit", this.exitHandler);
     for (const signal of ["SIGINT", "SIGTERM"] as const) {
       const handler = () => {
-        this.dispose();
+        void this.dispose();
         // Restore Node's default signal behavior after self-only cleanup.
         process.kill(process.pid, signal);
       };
@@ -155,7 +179,7 @@ export class SessionController {
 
   private unregisterExitHandler(): void {
     if (!this.exitHandler) return;
-    process.off("exit", this.exitHandler);
+    process.off("beforeExit", this.exitHandler);
     this.exitHandler = null;
     for (const [signal, handler] of this.signalHandlers) {
       process.off(signal, handler);

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -29,6 +29,9 @@ export class SessionController {
   private exitHandler: (() => void) | null = null;
   private signalHandlers = new Map<NodeJS.Signals, () => void>();
   private syncQueue: Promise<void> = Promise.resolve();
+  private disposing = false;
+  private disposePromise: Promise<void> | null = null;
+  private shuttingDown = false;
   private cleanedUp = false;
 
   public constructor(private readonly options: SessionControllerOptions) {}
@@ -57,6 +60,7 @@ export class SessionController {
   }
 
   public sync(): Promise<void> {
+    if (this.disposing) return this.syncQueue;
     this.syncQueue = this.syncQueue
       .then(() => this.syncNow())
       .catch((error: unknown) => {
@@ -103,14 +107,21 @@ export class SessionController {
   }
 
   public async dispose(): Promise<void> {
-    await this.stopWatching();
-    this.unregisterExitHandler();
-    const sessionPath = this.sessionPath;
-    if (sessionPath && !this.cleanedUp) {
-      await clearSessionArtifacts(sessionPath);
-      this.cleanedUp = true;
-    }
-    this.repository = null;
+    if (this.disposePromise) return this.disposePromise;
+
+    this.disposing = true;
+    this.disposePromise = (async () => {
+      await this.stopWatching();
+      await this.syncQueue;
+      this.unregisterExitHandler();
+      const sessionPath = this.sessionPath;
+      if (sessionPath && !this.cleanedUp) {
+        await clearSessionArtifacts(sessionPath);
+        this.cleanedUp = true;
+      }
+      this.repository = null;
+    })();
+    return this.disposePromise;
   }
 
   private async startWatching(): Promise<void> {
@@ -168,9 +179,12 @@ export class SessionController {
     process.once("beforeExit", this.exitHandler);
     for (const signal of ["SIGINT", "SIGTERM"] as const) {
       const handler = () => {
-        void this.dispose();
-        // Restore Node's default signal behavior after self-only cleanup.
-        process.kill(process.pid, signal);
+        if (this.shuttingDown) return;
+        this.shuttingDown = true;
+        void this.dispose().finally(() => {
+          // Restore Node's default signal behavior after self-only cleanup.
+          process.kill(process.pid, signal);
+        });
       };
       this.signalHandlers.set(signal, handler);
       process.once(signal, handler);

--- a/packages/core/src/node/snapshot/file.ts
+++ b/packages/core/src/node/snapshot/file.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import lockfile from "proper-lockfile";
 import { createEmptySnapshot } from "./serialize";
@@ -8,40 +8,29 @@ const LOCK_STALE_MS = 15_000;
 const LOCK_MAX_ATTEMPTS = 10;
 const LOCK_BACKOFF_MS = { min: 50, max: 500, factor: 1.5 } as const;
 
-const sleepSync = (ms: number) => {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-};
-
-const acquireLockSync = (sessionPath: string): (() => void) => {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      // retries are async-only in proper-lockfile; backoff here for lockSync.
-      return lockfile.lockSync(sessionPath, {
-        stale: LOCK_STALE_MS,
-        realpath: false,
-      });
-    } catch (error) {
-      lastError = error;
-      if (attempt === LOCK_MAX_ATTEMPTS - 1) break;
-      const delay = Math.min(
-        LOCK_BACKOFF_MS.min * LOCK_BACKOFF_MS.factor ** attempt,
-        LOCK_BACKOFF_MS.max
-      );
-      sleepSync(delay);
-    }
+const pathExists = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    if (isEnoent(error)) return false;
+    throw error;
   }
-
-  throw new Error(
-    `Failed to acquire session snapshot lock: ${sessionPath}`,
-    { cause: lastError }
-  );
 };
 
-export const readSnapshot = (sessionPath: string): SessionSnapshot | null => {
-  if (!fs.existsSync(sessionPath)) return null;
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 
-  const raw = fs.readFileSync(sessionPath, "utf8");
+export const readSnapshot = async (
+  sessionPath: string
+): Promise<SessionSnapshot | null> => {
+  let raw: string;
+  try {
+    raw = await fs.readFile(sessionPath, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
+  }
   if (!raw.trim()) {
     throw new Error(`Session snapshot is empty: ${sessionPath}`);
   }
@@ -64,18 +53,19 @@ export const readSnapshot = (sessionPath: string): SessionSnapshot | null => {
   return parsed.data;
 };
 
-export const readSnapshotOrEmpty = (sessionPath: string): SessionSnapshot =>
-  readSnapshot(sessionPath) ?? createEmptySnapshot();
+export const readSnapshotOrEmpty = async (
+  sessionPath: string
+): Promise<SessionSnapshot> => (await readSnapshot(sessionPath)) ?? createEmptySnapshot();
 
-export const writeSnapshot = (
+export const writeSnapshot = async (
   sessionPath: string,
   snapshot: SessionSnapshot
-) => {
+): Promise<void> => {
   const dir = path.dirname(sessionPath);
-  fs.mkdirSync(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true });
   const tmpPath = `${sessionPath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpPath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
-  fs.renameSync(tmpPath, sessionPath);
+  await fs.writeFile(tmpPath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  await fs.rename(tmpPath, sessionPath);
 };
 
 /**
@@ -85,24 +75,33 @@ export const writeSnapshot = (
  * Locks a stable sidecar (`*.lock`) so atomic rename of the snapshot
  * does not drop the inter-process exclusion.
  */
-export const withLockedMutation = (
+export const withLockedMutation = async (
   sessionPath: string,
   mutate: (prev: SessionSnapshot) => SessionSnapshot
-): SessionSnapshot => {
+): Promise<SessionSnapshot> => {
   const dir = path.dirname(sessionPath);
-  fs.mkdirSync(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true });
 
-  if (!fs.existsSync(sessionPath)) {
-    writeSnapshot(sessionPath, createEmptySnapshot());
+  if (!(await pathExists(sessionPath))) {
+    await writeSnapshot(sessionPath, createEmptySnapshot());
   }
 
-  const release = acquireLockSync(sessionPath);
+  const release = await lockfile.lock(sessionPath, {
+    stale: LOCK_STALE_MS,
+    realpath: false,
+    retries: {
+      retries: LOCK_MAX_ATTEMPTS - 1,
+      minTimeout: LOCK_BACKOFF_MS.min,
+      maxTimeout: LOCK_BACKOFF_MS.max,
+      factor: LOCK_BACKOFF_MS.factor,
+    },
+  });
   try {
-    const prev = readSnapshotOrEmpty(sessionPath);
+    const prev = await readSnapshotOrEmpty(sessionPath);
     const next = mutate(prev);
-    writeSnapshot(sessionPath, next);
+    await writeSnapshot(sessionPath, next);
     return next;
   } finally {
-    release();
+    await release();
   }
 };

--- a/packages/core/src/node/snapshot/mutations.ts
+++ b/packages/core/src/node/snapshot/mutations.ts
@@ -4,99 +4,49 @@ import { bumpSnapshot } from "./serialize";
 import { readSnapshotOrEmpty, withLockedMutation } from "./file";
 import { SessionSnapshot, SerializableFlattenHandler } from "./types";
 
-export const listSnapshotHandlers = (
-  sessionPath: string
-): SerializableFlattenHandler[] =>
-  readSnapshotOrEmpty(sessionPath).state.flattenHandlers;
+export const listSnapshotHandlers = async (sessionPath: string): Promise<SerializableFlattenHandler[]> =>
+  (await readSnapshotOrEmpty(sessionPath)).state.flattenHandlers;
 
-export const getSnapshotHandler = (
+export const getSnapshotHandler = async (
   sessionPath: string,
   id: string
-): SerializableFlattenHandler | undefined =>
-  listSnapshotHandlers(sessionPath).find((h) => h.id === id);
+): Promise<SerializableFlattenHandler | undefined> =>
+  (await listSnapshotHandlers(sessionPath)).find((handler) => handler.id === id);
 
 export const setSnapshotBehavior = (
-  sessionPath: string,
-  id: string,
-  behavior: HttpHandlerBehavior
-): SessionSnapshot =>
-  withLockedMutation(sessionPath, (prev) => {
-    const target = prev.state.flattenHandlers.find((h) => h.id === id);
-    if (!target) {
-      throw new Error(`Handler not found for id: ${id}`);
-    }
-    return bumpSnapshot(prev, {
-      flattenHandlers: prev.state.flattenHandlers.map((h) =>
-        h.id === id ? { ...h, behavior } : h
-      ),
-    });
-  });
+  sessionPath: string, id: string, behavior: HttpHandlerBehavior
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  if (!prev.state.flattenHandlers.some((handler) => handler.id === id)) throw new Error(`Handler not found for id: ${id}`);
+  return bumpSnapshot(prev, { flattenHandlers: prev.state.flattenHandlers.map((handler) => handler.id === id ? { ...handler, behavior } : handler) });
+});
 
 export const setSnapshotCustomResponse = (
-  sessionPath: string,
-  id: string,
-  customResponse: CustomResponse
-): SessionSnapshot =>
-  withLockedMutation(sessionPath, (prev) => {
-    const target = prev.state.flattenHandlers.find((h) => h.id === id);
-    if (!target) {
-      throw new Error(`Handler not found for id: ${id}`);
-    }
-    return bumpSnapshot(prev, {
-      flattenHandlers: prev.state.flattenHandlers.map((h) =>
-        h.id === id ? { ...h, customResponse } : h
-      ),
-    });
-  });
+  sessionPath: string, id: string, customResponse: CustomResponse
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  if (!prev.state.flattenHandlers.some((handler) => handler.id === id)) throw new Error(`Handler not found for id: ${id}`);
+  return bumpSnapshot(prev, { flattenHandlers: prev.state.flattenHandlers.map((handler) => handler.id === id ? { ...handler, customResponse } : handler) });
+});
 
 export const addSnapshotTempHandler = (
-  sessionPath: string,
-  data: TempHandlerInput
-): SessionSnapshot =>
-  withLockedMutation(sessionPath, (prev) => {
-    const id = getRowId({ path: data.path, method: data.method });
-    if (prev.state.flattenHandlers.some((h) => h.id === id)) {
-      throw new Error(`Duplicate handler id: ${id}. Change method or path.`);
-    }
-    const entry: SerializableFlattenHandler = {
-      id,
-      path: data.path,
-      method: data.method,
-      behavior: HttpHandlerBehavior.DEFAULT,
-      type: "temp",
-      tempInput: data,
-    };
-    return bumpSnapshot(prev, {
-      flattenHandlers: [...prev.state.flattenHandlers, entry],
-    });
-  });
+  sessionPath: string, data: TempHandlerInput
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const id = getRowId({ path: data.path, method: data.method });
+  if (prev.state.flattenHandlers.some((handler) => handler.id === id)) throw new Error(`Duplicate handler id: ${id}. Change method or path.`);
+  const entry: SerializableFlattenHandler = { id, path: data.path, method: data.method, behavior: HttpHandlerBehavior.DEFAULT, type: "temp", tempInput: data };
+  return bumpSnapshot(prev, { flattenHandlers: [...prev.state.flattenHandlers, entry] });
+});
 
 export const removeSnapshotTempHandler = (
-  sessionPath: string,
-  id: string
-): SessionSnapshot =>
-  withLockedMutation(sessionPath, (prev) => {
-    const target = prev.state.flattenHandlers.find((h) => h.id === id);
-    if (!target) {
-      throw new Error(`Handler not found for the given id: ${id}`);
-    }
-    if (target.type !== "temp") {
-      throw new Error(
-        `Handlers generated from codebase cannot be deleted (id: ${id}). You can only disable them.`
-      );
-    }
-    return bumpSnapshot(prev, {
-      flattenHandlers: prev.state.flattenHandlers.filter((h) => h.id !== id),
-    });
-  });
+  sessionPath: string, id: string
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const target = prev.state.flattenHandlers.find((handler) => handler.id === id);
+  if (!target) throw new Error(`Handler not found for the given id: ${id}`);
+  if (target.type !== "temp") throw new Error(`Handlers generated from codebase cannot be deleted (id: ${id}). You can only disable them.`);
+  return bumpSnapshot(prev, { flattenHandlers: prev.state.flattenHandlers.filter((handler) => handler.id !== id) });
+});
 
-export const requestSnapshotReset = (sessionPath: string): SessionSnapshot =>
-  withLockedMutation(sessionPath, (prev) =>
-    bumpSnapshot(prev, {
-      flattenHandlers: prev.state.flattenHandlers,
-      pendingReset: true,
-    })
-  );
+export const requestSnapshotReset = (sessionPath: string): Promise<SessionSnapshot> =>
+  withLockedMutation(sessionPath, (prev) => bumpSnapshot(prev, { flattenHandlers: prev.state.flattenHandlers, pendingReset: true }));
 
-export const readSessionSnapshot = (sessionPath: string): SessionSnapshot =>
+export const readSessionSnapshot = (sessionPath: string): Promise<SessionSnapshot> =>
   readSnapshotOrEmpty(sessionPath);

--- a/packages/core/src/node/snapshot/repository.ts
+++ b/packages/core/src/node/snapshot/repository.ts
@@ -15,21 +15,21 @@ import { SessionSnapshot } from "./types";
 export class SnapshotRepository {
   public constructor(public readonly sessionPath: string) {}
 
-  public read(): SessionSnapshot | null {
+  public read(): Promise<SessionSnapshot | null> {
     return readSnapshot(this.sessionPath);
   }
 
-  public readOrEmpty(): SessionSnapshot {
+  public readOrEmpty(): Promise<SessionSnapshot> {
     return readSnapshotOrEmpty(this.sessionPath);
   }
 
-  public write(snapshot: SessionSnapshot): void {
-    writeSnapshot(this.sessionPath, snapshot);
+  public write(snapshot: SessionSnapshot): Promise<void> {
+    return writeSnapshot(this.sessionPath, snapshot);
   }
 
   public mutate(
     mutate: (previous: SessionSnapshot) => SessionSnapshot
-  ): SessionSnapshot {
+  ): Promise<SessionSnapshot> {
     return withLockedMutation(this.sessionPath, mutate);
   }
 }

--- a/packages/core/src/node/snapshot/sessionPath.ts
+++ b/packages/core/src/node/snapshot/sessionPath.ts
@@ -1,6 +1,9 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { SESSION_DIR, SESSIONS_DIR } from "./types";
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 
 export const getSessionsDirectory = (cwd = process.cwd()) =>
   path.join(cwd, SESSION_DIR, SESSIONS_DIR);
@@ -8,23 +11,30 @@ export const getSessionsDirectory = (cwd = process.cwd()) =>
 export const getSessionPathForPid = (pid: number, cwd = process.cwd()) =>
   path.join(getSessionsDirectory(cwd), `${pid}.json`);
 
-export const listSessionPids = (cwd = process.cwd()): number[] => {
-  const dir = getSessionsDirectory(cwd);
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .map((file) => /^([0-9]+)\.json$/.exec(file)?.[1])
-    .filter((pid): pid is string => Boolean(pid))
-    .map(Number)
-    .sort((a, b) => a - b);
+export const listSessionPids = async (cwd = process.cwd()): Promise<number[]> => {
+  try {
+    const files = await fs.readdir(getSessionsDirectory(cwd));
+    return files
+      .map((file) => /^([0-9]+)\.json$/.exec(file)?.[1])
+      .filter((pid): pid is string => Boolean(pid))
+      .map(Number)
+      .sort((a, b) => a - b);
+  } catch (error) {
+    if (isEnoent(error)) return [];
+    throw error;
+  }
 };
 
-export const ensureSessionPath = (cwd = process.cwd(), pid = process.pid): string => {
+export const ensureSessionPath = async (
+  cwd = process.cwd(),
+  pid = process.pid
+): Promise<string> => {
   const sessionPath = getSessionPathForPid(pid, cwd);
-  fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
+  await fs.mkdir(path.dirname(sessionPath), { recursive: true });
   return sessionPath;
 };
 
-export const clearSessionArtifacts = (sessionPath: string) => {
-  fs.rmSync(sessionPath, { force: true });
-  fs.rmSync(`${sessionPath}.lock`, { force: true });
+export const clearSessionArtifacts = async (sessionPath: string): Promise<void> => {
+  await fs.rm(sessionPath, { force: true });
+  await fs.rm(`${sessionPath}.lock`, { force: true });
 };

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -41,7 +41,7 @@ afterEach(() => {
 });
 
 describe("snapshot file protocol", () => {
-  it("writes and reads snapshots atomically", () => {
+  it("writes and reads snapshots atomically", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
     const snap = bumpSnapshot(createEmptySnapshot(), {
@@ -55,14 +55,14 @@ describe("snapshot file protocol", () => {
         },
       ],
     });
-    writeSnapshot(sessionPath, snap);
-    expect(readSnapshot(sessionPath)).toEqual(snap);
+    await writeSnapshot(sessionPath, snap);
+    expect(await readSnapshot(sessionPath)).toEqual(snap);
   });
 
-  it("bumps revision on setSnapshotBehavior", () => {
+  it("bumps revision on setSnapshotBehavior", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
-    writeSnapshot(
+    await writeSnapshot(
       sessionPath,
       bumpSnapshot(createEmptySnapshot(), {
         flattenHandlers: [
@@ -77,7 +77,7 @@ describe("snapshot file protocol", () => {
       })
     );
 
-    const next = setSnapshotBehavior(
+    const next = await setSnapshotBehavior(
       sessionPath,
       JSON.stringify({ path: "/api", method: "get" }),
       HttpHandlerBehavior.DELAY
@@ -86,14 +86,14 @@ describe("snapshot file protocol", () => {
     expect(next.state.flattenHandlers[0]?.behavior).toBe(HttpHandlerBehavior.DELAY);
   });
 
-  it("stores a custom response without changing behavior", () => {
+  it("stores a custom response without changing behavior", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
-    writeSnapshot(sessionPath, bumpSnapshot(createEmptySnapshot(), {
+    await writeSnapshot(sessionPath, bumpSnapshot(createEmptySnapshot(), {
       flattenHandlers: [{ id: "a", path: "/api", method: HttpMethod.GET, behavior: HttpHandlerBehavior.DEFAULT, type: "default" }],
     }));
 
-    const next = setSnapshotCustomResponse(sessionPath, "a", {
+    const next = await setSnapshotCustomResponse(sessionPath, "a", {
       status: 201,
       body: "created",
       headers: { "X-Created": "yes" },
@@ -102,12 +102,12 @@ describe("snapshot file protocol", () => {
     expect(next).toMatchObject({ revision: 2, state: { flattenHandlers: [{ behavior: HttpHandlerBehavior.DEFAULT, customResponse: { status: 201, body: "created" } }] } });
   });
 
-  it("adds temp handlers with tempInput", () => {
+  it("adds temp handlers with tempInput", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
-    writeSnapshot(sessionPath, createEmptySnapshot());
+    await writeSnapshot(sessionPath, createEmptySnapshot());
 
-    const next = addSnapshotTempHandler(sessionPath, {
+    const next = await addSnapshotTempHandler(sessionPath, {
       path: "/api/tmp",
       method: HttpMethod.GET,
       contentType: MimeType.APPLICATION_JSON,
@@ -120,22 +120,22 @@ describe("snapshot file protocol", () => {
     expect(next.state.flattenHandlers[0]?.tempInput?.path).toBe("/api/tmp");
   });
 
-  it("uses PID-named session files in the caller cwd", () => {
+  it("uses PID-named session files in the caller cwd", async () => {
     const dir = makeTempDir();
     const sessionPath = getSessionPathForPid(4182, dir);
-    writeSnapshot(sessionPath, createEmptySnapshot());
+    await writeSnapshot(sessionPath, createEmptySnapshot());
     expect(sessionPath).toBe(path.join(dir, ".msw-dev-tool", "sessions", "4182.json"));
-    expect(listSessionPids(dir)).toEqual([4182]);
+    expect(await listSessionPids(dir)).toEqual([4182]);
   });
 
-  it("applies sequential locked mutations without lost updates", () => {
+  it("applies sequential locked mutations without lost updates", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
-    writeSnapshot(sessionPath, createEmptySnapshot());
+    await writeSnapshot(sessionPath, createEmptySnapshot());
 
     const writerCount = 20;
     for (let i = 0; i < writerCount; i += 1) {
-      withLockedMutation(sessionPath, (prev) =>
+      await withLockedMutation(sessionPath, (prev) =>
         bumpSnapshot(prev, {
           flattenHandlers: [
             ...prev.state.flattenHandlers,
@@ -151,7 +151,7 @@ describe("snapshot file protocol", () => {
       );
     }
 
-    const final = readSnapshot(sessionPath);
+    const final = await readSnapshot(sessionPath);
     expect(final?.revision).toBe(writerCount);
     expect(final?.state.flattenHandlers).toHaveLength(writerCount);
     expect(final?.state.flattenHandlers.map((h) => h.id).sort()).toEqual(
@@ -162,7 +162,7 @@ describe("snapshot file protocol", () => {
   it("serializes multi-process writers without lost updates", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
-    writeSnapshot(sessionPath, createEmptySnapshot());
+    await writeSnapshot(sessionPath, createEmptySnapshot());
 
     const writerScript = path.join(dir, "writer.cjs");
     const lockfileEntry = require.resolve("proper-lockfile");
@@ -244,7 +244,7 @@ try {
 
     await Promise.all(children);
 
-    const final = readSnapshot(sessionPath);
+    const final = await readSnapshot(sessionPath);
     expect(final?.revision).toBe(writerCount);
     expect(final?.state.flattenHandlers).toHaveLength(writerCount);
     expect(final?.state.flattenHandlers.map((h) => h.id).sort()).toEqual(
@@ -252,11 +252,11 @@ try {
     );
   });
 
-  it("throws on corrupt snapshot JSON", () => {
+  it("throws on corrupt snapshot JSON", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
     fs.writeFileSync(sessionPath, "{not-json", "utf8");
-    expect(() => readSnapshot(sessionPath)).toThrow(/Invalid JSON/);
+    await expect(readSnapshot(sessionPath)).rejects.toThrow(/Invalid JSON/);
   });
 
   it("preserves pendingReset across unrelated bumps", () => {

--- a/packages/node-cli/src/cli/context.ts
+++ b/packages/node-cli/src/cli/context.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
 import { getSessionPathForPid, listSessionPids } from "@msw-dev-tool/core/node/internal";
+import fs from "node:fs/promises";
 import { CliCommandContext } from "@msw-dev-tool/cli-core";
 import { FileSnapshotCliSession } from "./session";
 
@@ -13,21 +13,23 @@ export const toCommandContext = ({ sessionPath, pid }: CliContext): CliCommandCo
   metadata: { sessionPath, pid },
 });
 
-export const createCliContext = (
+export const createCliContext = async (
   flags: Record<string, string | boolean>
-): CliContext => {
+): Promise<CliContext> => {
   const fromFlag = flags.pid;
   if (typeof fromFlag === "string" && /^\d+$/.test(fromFlag)) {
     const pid = Number(fromFlag);
     const sessionPath = getSessionPathForPid(pid);
-    if (!fs.existsSync(sessionPath)) {
+    try {
+      await fs.access(sessionPath);
+    } catch {
       throw new Error(`No msw-dev-tool session found for PID ${pid} in this working directory.`);
     }
     return { pid, sessionPath };
   }
   if (fromFlag !== undefined) throw new Error("--pid must be a numeric process ID");
 
-  const pids = listSessionPids();
+  const pids = await listSessionPids();
   if (pids.length === 0) {
     throw new Error(
       "No msw-dev-tool sessions found. Start a Node process with setupDevToolServer() first."

--- a/packages/node-cli/src/cli/session.ts
+++ b/packages/node-cli/src/cli/session.ts
@@ -21,38 +21,38 @@ const toInfo = (snapshot: { revision: number; state: { pendingReset?: boolean; f
 /** File-backed adapter for Node snapshot envelopes. */
 export class FileSnapshotCliSession implements CliSession {
   public constructor(private readonly sessionPath: string) {}
-  public async describe() { return toInfo(readSessionSnapshot(this.sessionPath)); }
+  public async describe() { return toInfo(await readSessionSnapshot(this.sessionPath)); }
   public async list() { return listSnapshotHandlers(this.sessionPath); }
   public async get(id: string) { return getSnapshotHandler(this.sessionPath, id); }
   public async setBehavior(id: string, behavior: Parameters<typeof setSnapshotBehavior>[2]) {
-    const snapshot = setSnapshotBehavior(this.sessionPath, id, behavior);
+    const snapshot = await setSnapshotBehavior(this.sessionPath, id, behavior);
     await settleAfterWrite();
     const handler = snapshot.state.flattenHandlers.find((entry) => entry.id === id);
     if (!handler) throw new Error(`Handler not found for id: ${id}`);
     return { ...toInfo(snapshot), handler };
   }
   public async setCustomResponse(id: string, response: Parameters<typeof setSnapshotCustomResponse>[2]) {
-    const snapshot = setSnapshotCustomResponse(this.sessionPath, id, response);
+    const snapshot = await setSnapshotCustomResponse(this.sessionPath, id, response);
     await settleAfterWrite();
     const handler = snapshot.state.flattenHandlers.find((entry) => entry.id === id);
     if (!handler) throw new Error(`Handler not found for id: ${id}`);
     return { ...toInfo(snapshot), handler };
   }
   public async addTemp(data: Parameters<typeof addSnapshotTempHandler>[1]) {
-    const snapshot = addSnapshotTempHandler(this.sessionPath, data);
+    const snapshot = await addSnapshotTempHandler(this.sessionPath, data);
     await settleAfterWrite();
     const handler = snapshot.state.flattenHandlers.at(-1);
     if (!handler) throw new Error("Temporary handler was not added");
     return { ...toInfo(snapshot), handler };
   }
   public async removeTemp(id: string) {
-    const snapshot = removeSnapshotTempHandler(this.sessionPath, id);
+    const snapshot = await removeSnapshotTempHandler(this.sessionPath, id);
     await settleAfterWrite();
     return toInfo(snapshot);
   }
   public async reset() {
-    requestSnapshotReset(this.sessionPath);
+    await requestSnapshotReset(this.sessionPath);
     await settleAfterWrite();
-    return toInfo(readSessionSnapshot(this.sessionPath));
+    return toInfo(await readSessionSnapshot(this.sessionPath));
   }
 }

--- a/packages/node-cli/src/run.test.ts
+++ b/packages/node-cli/src/run.test.ts
@@ -25,7 +25,7 @@ const createSessionFile = (pid = 4182) => {
   return { pid, sessionPath };
 };
 
-const runWithJsonOutput = async (argv: string[], settle = false) => {
+const runWithJsonOutput = async (argv: string[]) => {
   const logs: string[] = [];
   const originalWrite = process.stdout.write.bind(process.stdout);
   process.stdout.write = ((chunk: string | Uint8Array) => {
@@ -33,9 +33,7 @@ const runWithJsonOutput = async (argv: string[], settle = false) => {
     return true;
   }) as typeof process.stdout.write;
   try {
-    const running = runCli(argv);
-    if (settle) await vi.advanceTimersByTimeAsync(300);
-    await running;
+    await runCli(argv);
   } finally {
     process.stdout.write = originalWrite;
   }
@@ -60,8 +58,7 @@ describe("node-cli", () => {
   it("automatically selects the only session and applies a mutation", async () => {
     const { pid } = createSessionFile();
     const id = JSON.stringify({ path: "/api/items", method: "get" });
-    vi.useFakeTimers();
-    const payload = await runWithJsonOutput(["set-behavior", id, "delay"], true);
+    const payload = await runWithJsonOutput(["set-behavior", id, "delay"]);
     expect(payload).toMatchObject({ ok: true, pid, revision: 1, handler: { behavior: "delay" } });
   });
 

--- a/packages/node-cli/src/run.ts
+++ b/packages/node-cli/src/run.ts
@@ -40,13 +40,13 @@ export const runCli = async (argv: string[]): Promise<void> => {
   }
 
   if (commandName === "sessions") {
-    printJson({ ok: true, sessions: listSessionPids().map((pid) => ({ pid })) });
+    printJson({ ok: true, sessions: (await listSessionPids()).map((pid) => ({ pid })) });
     return;
   }
 
   const command = findCommand(commandName);
   if (!command) throw new Error(`Unknown command: ${commandName}\n\n${usage}`);
 
-  const context = toCommandContext(createCliContext(flags));
+  const context = toCommandContext(await createCliContext(flags));
   printJson(await command.execute(context, { flags, positionals }));
 };

--- a/scripts/resolve-workspace-protocol.ts
+++ b/scripts/resolve-workspace-protocol.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs/promises';
 import path from 'path';
 
 interface PackageJson {
@@ -11,12 +11,14 @@ interface PackageJson {
 
 const PACKAGES_DIR = path.join(process.cwd(), 'packages');
 
-function readPackageJson(packagePath: string): PackageJson | null {
+async function readPackageJson(packagePath: string): Promise<PackageJson | null> {
   const packageJsonPath = path.join(packagePath, 'package.json');
-  if (!fs.existsSync(packageJsonPath)) {
-    return null;
+  try {
+    return JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
   }
-  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 }
 
 function updateDependencies(packageJson: PackageJson, workspacePackages: Map<string, string>): PackageJson {
@@ -41,29 +43,32 @@ function updateDependencies(packageJson: PackageJson, workspacePackages: Map<str
   };
 }
 
-function main() {
+async function main() {
   const workspacePackages = new Map<string, string>();
-  const packageDirs = fs.readdirSync(PACKAGES_DIR)
+  const packageDirs = await fs.readdir(PACKAGES_DIR);
 
-  packageDirs.forEach(dir => {
+  for (const dir of packageDirs) {
     const packagePath = path.join(PACKAGES_DIR, dir);
-    const packageJson = readPackageJson(packagePath);
+    const packageJson = await readPackageJson(packagePath);
     if (packageJson) {
       workspacePackages.set(packageJson.name, packageJson.version);
     }
-  });
+  }
 
-  packageDirs.forEach(dir => {
+  for (const dir of packageDirs) {
     const packagePath = path.join(PACKAGES_DIR, dir);
-    const packageJson = readPackageJson(packagePath);
+    const packageJson = await readPackageJson(packagePath);
     if (packageJson) {
       const updatedPackageJson = updateDependencies(packageJson, workspacePackages);
-      fs.writeFileSync(
+      await fs.writeFile(
         path.join(packagePath, 'package.json'),
         JSON.stringify(updatedPackageJson, null, 2) + '\n'
       );
     }
-  });
+  }
 }
 
-main(); 
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,7 @@ __metadata:
     "@types/node": "npm:^22.13.10"
     "@types/proper-lockfile": "npm:^4.1.4"
     "@types/react": "npm:^18 || ^19"
+    chokidar: "npm:^5.0.0"
     eslint: "npm:^9.24.0"
     globals: "npm:^16.0.0"
     happy-dom: "npm:^20.11.1"
@@ -5393,6 +5394,15 @@ __metadata:
     "@chevrotain/utils": "npm:11.0.3"
     lodash-es: "npm:4.17.21"
   checksum: 10c0/ffd425fa321e3f17e9833d7f44cd39f2743f066e92ca74b226176080ca5d455f853fe9091cdfd86354bd899d85c08b3bdc3f55b267e7d07124b048a88349765f
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "chokidar@npm:5.0.0"
+  dependencies:
+    readdirp: "npm:^5.0.0"
+  checksum: 10c0/42fc907cb2a7ff5c9e220f84dae75380a77997f851c2a5e7865a2cf9ae45dd407a23557208cdcdbf3ac8c93341135a1748e4c48c31855f3bfa095e5159b6bdec
   languageName: node
   linkType: hard
 
@@ -11874,6 +11884,13 @@ __metadata:
     pify: "npm:^4.0.1"
     strip-bom: "npm:^3.0.0"
   checksum: 10c0/85a9ba08bb93f3c91089bab4f1603995ec7156ee595f8ce40ae9f49d841cbb586511508bd47b7cf78c97f678c679b2c6e2c0092e63f124214af41b6f8a25ca31
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "readdirp@npm:5.1.1"
+  checksum: 10c0/5e99755684b9104761e48801828f4d2614efa33b1698629929c5985184dc63a7f8233c827832c40dc7be16b00cc871d303cf9de396d2fb74b9465ee2aa2424a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- replace synchronous Node session file operations with `node:fs/promises`
- use Chokidar for session-file updates and serialize concurrent syncs
- make Node CLI snapshot/session access asynchronous and enforce async fs imports in core runtime code

## Verification
- yarn workspace @msw-dev-tool/core typecheck
- yarn workspace @msw-dev-tool/node-cli typecheck
- yarn workspace @msw-dev-tool/core lint
- yarn workspace @msw-dev-tool/core test

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Snapshot and session operations now complete asynchronously for more responsive tooling.
  * Session changes are detected and synchronized more reliably during file updates.
  * Session startup, disposal, resets, and watcher shutdown now complete more gracefully.
  * CLI session discovery and commands wait consistently for session data.
  * Missing session files are handled without disrupting normal workflows.

* **Bug Fixes**
  * Improved reliability during concurrent snapshot updates.
  * Added safer handling for failed session startup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->