### PR TITLE
docs: clarify browser CLI Chrome MCP setup

### DIFF
--- a/packages/docs/app/docs/(features)/browser-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/browser-cli/page.mdx
@@ -72,11 +72,9 @@ command = "npx"
 args = ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"]
 ```
 
-Add the server globally to make it available across projects, or add it as a
-project-local MCP to limit it to this project. The MCP ID in this example is
-`chrome-devtools`; to connect to another Chrome instance, replace it with a
-unique ID such as `chrome-devtools-msw` in the `[mcp_servers.<id>]` header and
-use that ID in your agent instruction.
+When using a separate server through a global MCP configuration, you can assign
+it a different ID in the `[mcp_servers.<id>]` header. You can also configure the
+server as a project-local MCP.
 
 Your MCP client and `msw-dev-tool-browser` can then inspect the same Chrome tabs. See
 the [Chrome DevTools MCP guide for connecting to a running Chrome instance](https://github.com/ChromeDevTools/chrome-devtools-mcp#connecting-to-a-running-chrome-instance)

--- a/packages/docs/app/docs/(features)/browser-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/browser-cli/page.mdx
@@ -64,13 +64,19 @@ access.
 
 ### Install a dedicated Chrome DevTools MCP server
 
-Configure a separate Chrome DevTools MCP server to connect to the same endpoint:
+We recommend configuring a dedicated Chrome DevTools MCP server for this endpoint:
 
 ```toml copy
 [mcp_servers.chrome-devtools]
 command = "npx"
 args = ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"]
 ```
+
+Add the server globally to make it available across projects, or add it as a
+project-local MCP to limit it to this project. The MCP ID in this example is
+`chrome-devtools`; to connect to another Chrome instance, replace it with a
+unique ID such as `chrome-devtools-msw` in the `[mcp_servers.<id>]` header and
+use that ID in your agent instruction.
 
 Your MCP client and `msw-dev-tool-browser` can then inspect the same Chrome tabs. See
 the [Chrome DevTools MCP guide for connecting to a running Chrome instance](https://github.com/ChromeDevTools/chrome-devtools-mcp#connecting-to-a-running-chrome-instance)

--- a/packages/docs/app/docs/(features)/browser-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/browser-cli/page.mdx
@@ -2,7 +2,7 @@
 description: "Browser CLI for AI agents to control msw-dev-tool with Chrome DevTools Protocol"
 ---
 
-import { Callout } from "nextra/components";
+import { Callout, Tabs } from "nextra/components";
 
 # Browser CLI
 
@@ -22,19 +22,49 @@ and JSON output conventions as the Node CLI, but requires an explicit browser ta
 pnpm add -D @msw-dev-tool/browser-cli @msw-dev-tool/core msw
 ```
 
-Start the Chrome instance controlled by your AI with a remote-debugging port.
+## Chrome and MCP setup
+
+Start the Chrome instance controlled by your AI with remote debugging enabled.
 Use a separate profile: this port gives local processes full browser-debugging
 access.
 
-```bash copy
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-  --remote-debugging-port=9222 \
-  --user-data-dir=/tmp/msw-dev-tool-chrome
-```
+{/* prettier-ignore */}
+<Tabs items={["macOS", "Windows", "Linux"]}>
+  <Tabs.Tab>
+  ```bash copy
+  open -na "Google Chrome" --args \
+    --remote-debugging-address=127.0.0.1 \
+    --remote-debugging-port=9222 \
+    --user-data-dir=/private/tmp/chrome-debug-9222
+  ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+  ```powershell copy
+  & "C:\Program Files\Google\Chrome\Application\chrome.exe" `
+    --remote-debugging-address=127.0.0.1 `
+    --remote-debugging-port=9222 `
+    --user-data-dir="$env:TEMP\chrome-debug-9222"
+  ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+  ```bash copy
+  google-chrome \
+    --remote-debugging-address=127.0.0.1 \
+    --remote-debugging-port=9222 \
+    --user-data-dir=/tmp/chrome-debug-9222
+  ```
+  </Tabs.Tab>
+</Tabs>
 
-Configure your AI agent's Chrome DevTools MCP server to connect to the same
-endpoint. For example, in Codex add the following to `.codex/config.toml` and
-restart the MCP session:
+<Callout type="warning">
+  Before using Chrome DevTools MCP or `@msw-dev-tool/browser-cli`, keep the Chrome
+  instance started above running. Both connect to its `http://127.0.0.1:9222`
+  debugging endpoint, not to an ordinarily opened Chrome window.
+</Callout>
+
+### Install a dedicated Chrome DevTools MCP server
+
+Configure a separate Chrome DevTools MCP server to connect to the same endpoint:
 
 ```toml copy
 [mcp_servers.chrome-devtools]
@@ -45,6 +75,16 @@ args = ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222
 Your MCP client and `msw-dev-tool-browser` can then inspect the same Chrome tabs. See
 the [Chrome DevTools MCP guide for connecting to a running Chrome instance](https://github.com/ChromeDevTools/chrome-devtools-mcp#connecting-to-a-running-chrome-instance)
 for other operating systems and remote-debugging details.
+
+### Agent instruction
+
+Add the following instruction for agents that use the Browser CLI:
+
+```text copy
+When using @msw-dev-tool/browser-cli, use the chrome-devtools MCP server
+configured for http://127.0.0.1:9222. Before using it, make sure Chrome is
+running with the remote-debugging configuration shown above.
+```
 
 Your application must call `setupDevToolWorker(...handlers)` in the target tab.
 That registers the in-page control endpoint used by the CLI.


### PR DESCRIPTION
## Summary
- document OS-specific Chrome remote-debugging launch commands
- add dedicated Chrome DevTools MCP configuration guidance
- provide an agent instruction for using the MCP with @msw-dev-tool/browser-cli

## Validation
- yarn workspace docs build