### PR TITLE
feat(core): discover WebSocket handlers

### DIFF
--- a/.changeset/websocket-wrapper-foundation.md
+++ b/.changeset/websocket-wrapper-foundation.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": minor
+---
+
+Add the environment-neutral `@msw-dev-tool/core/msw` WebSocket wrapper and in-memory discovery of code-defined WebSocket endpoints and message listeners.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,11 @@
       "types": "./dist/types/node/internal.d.ts",
       "import": "./dist/esm/node/internal.js",
       "require": "./dist/cjs/node/internal.js"
+    },
+    "./msw": {
+      "types": "./dist/types/msw/index.d.ts",
+      "import": "./dist/esm/msw/index.js",
+      "require": "./dist/cjs/msw/index.js"
     }
   },
   "repository": "https://github.com/nayounsang/msw-dev-tool",

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -23,6 +23,7 @@ const entries = [
   { input: "src/shared/index.ts", file: "shared/index" },
   { input: "src/node/index.ts", file: "node/index" },
   { input: "src/node/internal.ts", file: "node/internal" },
+  { input: "src/msw/index.ts", file: "msw/index" },
 ];
 
 const jsConfigs = entries.map(({ input, file }) => ({

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
+import { ws } from "../msw";
 
 vi.mock("msw/browser", () => ({
   setupWorker: (...handlers: unknown[]) => ({
@@ -91,5 +92,22 @@ describe("browser control bridge", () => {
     expect(result.status).toBe(202);
     expect(result.headers.get("X-Custom")).toBe("yes");
     expect(await result.text()).toBe("custom body");
+  });
+
+  it("registers wrapped WebSocket endpoints through the browser store adapter", async () => {
+    const chat = ws.link("ws://browser.test/chat");
+    await setupDevToolWorker(
+      chat.addEventListener("connection", () => undefined)
+    );
+
+    expect(handlerStore.getState().webSocketEndpoints).toEqual([
+      expect.objectContaining({
+        endpoint: "ws://browser.test/chat",
+        source: "code",
+      }),
+    ]);
+    expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY)!)).toMatchObject({
+      state: { flattenHandlers: [] },
+    });
   });
 });

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -43,6 +43,8 @@ const mapState = (
   worker: base.runtime,
   restHandlers: base.restHandlers,
   flattenHandlers: base.flattenHandlers,
+  webSocketEndpoints: base.webSocketEndpoints,
+  webSocketListeners: base.webSocketListeners,
   setupDevToolWorker,
   resetMSWDevTool: base.resetMSWDevTool,
   addTempHandler: base.addTempHandler,
@@ -53,6 +55,8 @@ const mapState = (
   getHandlerCustomResponse: base.getHandlerCustomResponse,
   setHandlerCustomResponse: base.setHandlerCustomResponse,
   removeTempHandler: base.removeTempHandler,
+  registerCodeWebSocketEndpoint: base.registerCodeWebSocketEndpoint,
+  registerCodeWebSocketListener: base.registerCodeWebSocketListener,
 });
 
 // Guard against SSR ReferenceError: sessionStorage is not defined.
@@ -121,6 +125,10 @@ export const handlerStore: StoreApi<HandlerStoreState> = {
       basePartial.restHandlers = nextPartial.restHandlers;
     if ("flattenHandlers" in nextPartial)
       basePartial.flattenHandlers = nextPartial.flattenHandlers;
+    if ("webSocketEndpoints" in nextPartial)
+      basePartial.webSocketEndpoints = nextPartial.webSocketEndpoints;
+    if ("webSocketListeners" in nextPartial)
+      basePartial.webSocketListeners = nextPartial.webSocketListeners;
 
     baseStore.setState(basePartial);
   },

--- a/packages/core/src/msw/index.ts
+++ b/packages/core/src/msw/index.ts
@@ -1,0 +1,1 @@
+export { wrappedWs as ws } from "./websocket";

--- a/packages/core/src/msw/websocket.test.ts
+++ b/packages/core/src/msw/websocket.test.ts
@@ -89,4 +89,31 @@ describe("wrapped ws", () => {
     expect(await secondReply).toBe("reply:two");
     expect(store.getState().webSocketListeners).toHaveLength(1);
   });
+
+  it("keeps discovered listeners for already-connected clients after reset", async () => {
+    const chat = ws.link("ws://wrapper.test/reset");
+    const handler = chat.addEventListener("connection", ({ client }) => {
+      client.addEventListener("message", () => client.send("received"));
+    });
+    const store = createHandlerStore<SetupServer>({
+      createRuntime: (handlers) => setupServer(...handlers),
+    });
+    const server = await store.getState().setupDevToolRuntime(handler);
+    servers.push(server);
+    server.listen();
+
+    const socket = await openSocket("ws://wrapper.test/reset");
+    const beforeReset = nextMessage(socket);
+    socket.send("before reset");
+    expect(await beforeReset).toBe("received");
+    expect(store.getState().webSocketListeners).toHaveLength(1);
+
+    store.getState().resetMSWDevTool();
+
+    const afterReset = nextMessage(socket);
+    socket.send("after reset");
+    expect(await afterReset).toBe("received");
+    expect(store.getState().webSocketListeners).toHaveLength(1);
+  });
+
 });

--- a/packages/core/src/msw/websocket.test.ts
+++ b/packages/core/src/msw/websocket.test.ts
@@ -39,17 +39,20 @@ const nextMessage = (socket: WebSocket): Promise<string> =>
   });
 
 describe("wrapped ws", () => {
-  it("binds only setup handlers and discovers message listeners after connection", async () => {
+  it("binds setup handlers, discovers listeners, and restores them after reset", async () => {
     const chat = ws.link("ws://wrapper.test/chat");
     const ignored = ws.link("ws://wrapper.test/ignored");
+    const reset = ws.link("ws://wrapper.test/reset");
     const handler = chat.addEventListener("connection", ({ client }) => {
-      client.addEventListener("message", function (event) {
-        // The native client remains the listener receiver, so native methods work.
-        this.send(`reply:${event.data}`);
+      client.addEventListener("message", (event) => {
+        client.send(`reply:${event.data}`);
       }, { once: false });
       client.addEventListener("close", () => undefined, { once: true });
     });
     const ignoredHandler = ignored.addEventListener("connection", () => undefined);
+    const resetHandler = reset.addEventListener("connection", ({ client }) => {
+      client.addEventListener("message", () => client.send("received"));
+    });
     const descriptor = Object.getOwnPropertyDescriptor(handler, WEBSOCKET_HANDLER_BIND);
 
     expect(descriptor?.enumerable).toBe(false);
@@ -58,15 +61,19 @@ describe("wrapped ws", () => {
     const store = createHandlerStore<SetupServer>({
       createRuntime: (handlers) => setupServer(...handlers),
     });
-    const server = await store.getState().setupDevToolRuntime(handler);
+    const server = await store.getState().setupDevToolRuntime(handler, resetHandler);
     server.use(ignoredHandler);
     servers.push(server);
     server.listen();
 
     expect(store.getState().webSocketEndpoints).toEqual([
       { id: handler.id, endpoint: "ws://wrapper.test/chat", source: "code" },
+      { id: resetHandler.id, endpoint: "ws://wrapper.test/reset", source: "code" },
     ]);
     expect(store.getState().webSocketListeners).toEqual([]);
+
+    // Handlers added after setup are not bound to the dev-tool store.
+    await openSocket("ws://wrapper.test/ignored");
 
     const first = await openSocket("ws://wrapper.test/chat");
     const reply = nextMessage(first);
@@ -88,32 +95,19 @@ describe("wrapped ws", () => {
     second.send("two");
     expect(await secondReply).toBe("reply:two");
     expect(store.getState().webSocketListeners).toHaveLength(1);
-  });
-
-  it("keeps discovered listeners for already-connected clients after reset", async () => {
-    const chat = ws.link("ws://wrapper.test/reset");
-    const handler = chat.addEventListener("connection", ({ client }) => {
-      client.addEventListener("message", () => client.send("received"));
-    });
-    const store = createHandlerStore<SetupServer>({
-      createRuntime: (handlers) => setupServer(...handlers),
-    });
-    const server = await store.getState().setupDevToolRuntime(handler);
-    servers.push(server);
-    server.listen();
 
     const socket = await openSocket("ws://wrapper.test/reset");
     const beforeReset = nextMessage(socket);
     socket.send("before reset");
     expect(await beforeReset).toBe("received");
-    expect(store.getState().webSocketListeners).toHaveLength(1);
+    expect(store.getState().webSocketListeners).toHaveLength(2);
 
     store.getState().resetMSWDevTool();
 
     const afterReset = nextMessage(socket);
     socket.send("after reset");
     expect(await afterReset).toBe("received");
-    expect(store.getState().webSocketListeners).toHaveLength(1);
+    expect(store.getState().webSocketListeners).toHaveLength(2);
   });
 
 });

--- a/packages/core/src/msw/websocket.test.ts
+++ b/packages/core/src/msw/websocket.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setupServer, type SetupServer } from "msw/node";
+import { createHandlerStore } from "../shared/store";
+import { WEBSOCKET_HANDLER_BIND } from "../shared/websocket/bind";
+import { ws } from "./index";
+
+const servers: SetupServer[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(() => {
+  sockets.splice(0).forEach((socket) => socket.close());
+  servers.splice(0).forEach((server) => server.close());
+});
+
+const openSocket = async (url: string): Promise<WebSocket> => {
+  const socket = new WebSocket(url);
+  sockets.push(socket);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("WebSocket open timeout")), 2_000);
+    socket.addEventListener("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    socket.addEventListener("error", () => {
+      clearTimeout(timer);
+      reject(new Error("WebSocket open failed"));
+    });
+  });
+  return socket;
+};
+
+const nextMessage = (socket: WebSocket): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("WebSocket message timeout")), 2_000);
+    socket.addEventListener("message", (event) => {
+      clearTimeout(timer);
+      resolve(String(event.data));
+    }, { once: true });
+  });
+
+describe("wrapped ws", () => {
+  it("binds only setup handlers and discovers message listeners after connection", async () => {
+    const chat = ws.link("ws://wrapper.test/chat");
+    const ignored = ws.link("ws://wrapper.test/ignored");
+    const handler = chat.addEventListener("connection", ({ client }) => {
+      client.addEventListener("message", function (event) {
+        // The native client remains the listener receiver, so native methods work.
+        this.send(`reply:${event.data}`);
+      }, { once: false });
+      client.addEventListener("close", () => undefined, { once: true });
+    });
+    const ignoredHandler = ignored.addEventListener("connection", () => undefined);
+    const descriptor = Object.getOwnPropertyDescriptor(handler, WEBSOCKET_HANDLER_BIND);
+
+    expect(descriptor?.enumerable).toBe(false);
+    expect(Object.keys(handler)).not.toContain(String(WEBSOCKET_HANDLER_BIND));
+
+    const store = createHandlerStore<SetupServer>({
+      createRuntime: (handlers) => setupServer(...handlers),
+    });
+    const server = await store.getState().setupDevToolRuntime(handler);
+    server.use(ignoredHandler);
+    servers.push(server);
+    server.listen();
+
+    expect(store.getState().webSocketEndpoints).toEqual([
+      { id: handler.id, endpoint: "ws://wrapper.test/chat", source: "code" },
+    ]);
+    expect(store.getState().webSocketListeners).toEqual([]);
+
+    const first = await openSocket("ws://wrapper.test/chat");
+    const reply = nextMessage(first);
+    first.send("one");
+    expect(await reply).toBe("reply:one");
+    expect(store.getState().webSocketListeners).toEqual([
+      {
+        id: `${handler.id}:message:0`,
+        endpointId: handler.id,
+        order: 0,
+        event: "message",
+        source: "code",
+      },
+    ]);
+
+    // A second connection repeats registration order zero and is upserted.
+    const second = await openSocket("ws://wrapper.test/chat");
+    const secondReply = nextMessage(second);
+    second.send("two");
+    expect(await secondReply).toBe("reply:two");
+    expect(store.getState().webSocketListeners).toHaveLength(1);
+  });
+});

--- a/packages/core/src/msw/websocket.ts
+++ b/packages/core/src/msw/websocket.ts
@@ -7,6 +7,7 @@ import {
   attachWebSocketHandlerBindHook,
   type WebSocketStoreAdapter,
 } from "../shared/websocket/bind";
+import type { ManagedWebSocketListener } from "../shared/types";
 
 type WebSocketConnection = Parameters<WebSocketEventListener<"connection">>[0];
 type WebSocketClient = WebSocketConnection["client"];
@@ -21,7 +22,7 @@ const endpointFromMatcher = (matcher: string | RegExp): string =>
 const createProxyClient = (
   client: WebSocketClient,
   endpointId: string,
-  adapter: WebSocketStoreAdapter,
+  registerListener: (listener: ManagedWebSocketListener) => void,
 ): WebSocketClient => {
   let nextMessageListenerOrder = 0;
   /**
@@ -44,7 +45,7 @@ const createProxyClient = (
           // `error`) are reserved for future support.
           if (type === "message") {
             const order = nextMessageListenerOrder++;
-            adapter.registerCodeWebSocketListener({
+            registerListener({
               id: `${endpointId}:message:${order}`,
               endpointId,
               order,
@@ -82,6 +83,11 @@ const createWrappedLink = (
     addEventListener(event, listener) {
       let adapter: WebSocketStoreAdapter | undefined;
       let endpointId = "";
+      const discoveredListeners = new Map<string, ManagedWebSocketListener>();
+      const registerListener = (entry: ManagedWebSocketListener) => {
+        discoveredListeners.set(entry.id, entry);
+        adapter?.registerCodeWebSocketListener(entry);
+      };
       const handler = originalLink.addEventListener(event, (connection) => {
         if (!adapter) {
           listener(connection);
@@ -89,7 +95,7 @@ const createWrappedLink = (
         }
         listener({
           ...connection,
-          client: createProxyClient(connection.client, endpointId, adapter),
+          client: createProxyClient(connection.client, endpointId, registerListener),
         });
       });
 
@@ -104,7 +110,10 @@ const createWrappedLink = (
       hook.bind = (nextAdapter) => {
         bind.call(hook, nextAdapter);
         adapter = nextAdapter;
-        adapter.registerCodeWebSocketEndpoint(endpoint);
+        nextAdapter.registerCodeWebSocketEndpoint(endpoint);
+        discoveredListeners.forEach((entry) =>
+          nextAdapter.registerCodeWebSocketListener(entry)
+        );
       };
       return handler;
     },

--- a/packages/core/src/msw/websocket.ts
+++ b/packages/core/src/msw/websocket.ts
@@ -1,0 +1,123 @@
+import {
+  ws as originalWs,
+  type WebSocketEventListener,
+  type WebSocketLink,
+} from "msw";
+import {
+  attachWebSocketHandlerBindHook,
+  type WebSocketStoreAdapter,
+} from "../shared/websocket/bind";
+
+type WebSocketConnection = Parameters<WebSocketEventListener<"connection">>[0];
+type WebSocketClient = WebSocketConnection["client"];
+
+/**
+ * MSW does not expose a matcher-to-endpoint formatter,
+ * so format the matcher locally for display.
+ */
+const endpointFromMatcher = (matcher: string | RegExp): string =>
+  typeof matcher === "string" ? matcher : `/${matcher.source}/${matcher.flags}`;
+
+const createProxyClient = (
+  client: WebSocketClient,
+  endpointId: string,
+  adapter: WebSocketStoreAdapter,
+): WebSocketClient => {
+  let nextMessageListenerOrder = 0;
+  /**
+   * Cache method wrappers to preserve method identity and call native Client
+   * methods with the original Client as `this`.
+   */
+  const methods = new Map<PropertyKey, unknown>();
+
+  return new Proxy(client, {
+    get(target, property) {
+      const cached = methods.get(property);
+      if (cached) return cached;
+      if (property === "addEventListener") {
+        const addEventListener: WebSocketClient["addEventListener"] = (
+          type,
+          listener,
+          options,
+        ) => {
+          // Only message listeners are discovered. Lifecycle events (`close` and
+          // `error`) are reserved for future support.
+          if (type === "message") {
+            const order = nextMessageListenerOrder++;
+            adapter.registerCodeWebSocketListener({
+              id: `${endpointId}:message:${order}`,
+              endpointId,
+              order,
+              event: "message",
+              source: "code",
+            });
+          }
+          Reflect.apply(target.addEventListener, target, [
+            type,
+            listener,
+            options,
+          ]);
+        };
+        methods.set(property, addEventListener);
+        return addEventListener;
+      }
+
+      const value = Reflect.get(target, property, target);
+      // Read non-method properties from the original Client, including getters.
+      if (typeof value !== "function") return value;
+      // Bind methods so calls through the Proxy use the original Client as `this`.
+      const bound = value.bind(target);
+      methods.set(property, bound);
+      return bound;
+    },
+  });
+};
+
+const createWrappedLink = (
+  matcher: Parameters<typeof originalWs.link>[0],
+): WebSocketLink => {
+  const originalLink = originalWs.link(matcher);
+
+  return {
+    addEventListener(event, listener) {
+      let adapter: WebSocketStoreAdapter | undefined;
+      let endpointId = "";
+      const handler = originalLink.addEventListener(event, (connection) => {
+        if (!adapter) {
+          listener(connection);
+          return;
+        }
+        listener({
+          ...connection,
+          client: createProxyClient(connection.client, endpointId, adapter),
+        });
+      });
+
+      endpointId = handler.id;
+      const hook = attachWebSocketHandlerBindHook(handler);
+      const endpoint = {
+        id: endpointId,
+        endpoint: endpointFromMatcher(matcher),
+        source: "code" as const,
+      };
+      const bind = hook.bind;
+      hook.bind = (nextAdapter) => {
+        bind.call(hook, nextAdapter);
+        adapter = nextAdapter;
+        adapter.registerCodeWebSocketEndpoint(endpoint);
+      };
+      return handler;
+    },
+    get clients() {
+      return originalLink.clients;
+    },
+    broadcast(data) {
+      return originalLink.broadcast(data);
+    },
+    broadcastExcept(clients, data) {
+      return originalLink.broadcastExcept(clients, data);
+    },
+  };
+};
+
+export const wrappedWs: typeof originalWs = { link: createWrappedLink };

--- a/packages/core/src/node/handlerStore.test.ts
+++ b/packages/core/src/node/handlerStore.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { http, HttpResponse } from "msw";
+import { ws } from "../msw";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   nodeHandlerStore,
@@ -127,6 +128,22 @@ describe("setupDevToolServer", () => {
       nodeHandlerStore.getState().flattenHandlers.every((h) => h.type === "default")
     ).toBe(true);
     expect((await readSnapshot(sessionPath))?.state.pendingReset).toBeUndefined();
+  });
+
+  it("registers wrapped WebSocket endpoints in the Node Core store", async () => {
+    makeSession();
+    const chat = ws.link("ws://node.test/chat");
+    const server = await setupDevToolServer(
+      chat.addEventListener("connection", () => undefined)
+    );
+
+    expect(nodeHandlerStore.getState().webSocketEndpoints).toEqual([
+      expect.objectContaining({
+        endpoint: "ws://node.test/chat",
+        source: "code",
+      }),
+    ]);
+    server.close();
   });
 
 });

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -15,6 +15,7 @@ import {
   Handler,
 } from "../types";
 import { initMSWDevToolStore } from "../utils";
+import { bindWebSocketHandler } from "../websocket/bind";
 import { createStore, StoreApi } from "./createStore";
 import {
   CreateHandlerStoreOptions,
@@ -51,10 +52,20 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
       const lookupCustomResponse = (id: string) =>
         findHandlerCustomResponse(get().flattenHandlers, id);
 
+      const bindWebSocketHandlers = (handlers: readonly unknown[]) => {
+        const adapter = {
+          registerCodeWebSocketEndpoint: get().registerCodeWebSocketEndpoint,
+          registerCodeWebSocketListener: get().registerCodeWebSocketListener,
+        };
+        handlers.forEach((handler) => bindWebSocketHandler(handler, adapter));
+      };
+
       return {
         flattenHandlers: [],
         runtime: null,
         restHandlers: [],
+        webSocketEndpoints: [],
+        webSocketListeners: [],
         setupDevToolRuntime: async (...handlers: Handler[]) => {
           const wrapped = wrapHandlersWithBehavior(
             handlers,
@@ -91,7 +102,10 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             runtime,
             flattenHandlers: rehydratedHandlers,
             restHandlers: unsupportedHandlers,
+            webSocketEndpoints: [],
+            webSocketListeners: [],
           });
+          bindWebSocketHandlers(handlers);
 
           return runtime;
         },
@@ -106,7 +120,10 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             runtime,
             flattenHandlers,
             restHandlers: unsupportedHandlers,
+            webSocketEndpoints: [],
+            webSocketListeners: [],
           });
+          bindWebSocketHandlers(runtime.listHandlers());
         },
         addTempHandler: ({ data }) => {
           const { handler, flattenHandler } = buildTempHandler(
@@ -168,6 +185,32 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           set({
             runtime,
             flattenHandlers,
+          });
+        },
+        registerCodeWebSocketEndpoint: (endpoint) => {
+          if (
+            get().webSocketEndpoints.some(
+              (current) => current.id === endpoint.id
+            )
+          ) {
+            return;
+          }
+
+          set({
+            webSocketEndpoints: [...get().webSocketEndpoints, endpoint],
+          });
+        },
+        registerCodeWebSocketListener: (listener) => {
+          if (
+            get().webSocketListeners.some(
+              (current) => current.id === listener.id
+            )
+          ) {
+            return;
+          }
+
+          set({
+            webSocketListeners: [...get().webSocketListeners, listener],
           });
         },
       };

--- a/packages/core/src/shared/store/types.ts
+++ b/packages/core/src/shared/store/types.ts
@@ -1,4 +1,12 @@
-import { CustomResponse, FlattenHandler, Handler, HttpHandlerBehavior, TempHandlerInput } from "../types";
+import {
+  CustomResponse,
+  FlattenHandler,
+  Handler,
+  HttpHandlerBehavior,
+  ManagedWebSocketEndpoint,
+  ManagedWebSocketListener,
+  TempHandlerInput,
+} from "../types";
 import type { HydratableFlattenHandler } from "../utils/storage";
 import { ListHandlersRuntime } from "../utils";
 import { PersistOptions, StoreApi } from "./createStore";
@@ -9,7 +17,7 @@ export type MswDevToolRuntime = ListHandlersRuntime & {
 };
 
 export type HandlerStoreBaseState = {
-  /** GraphQL or WebSocket handlers are currently not supported. */
+  /** GraphQL handlers and unsupported handlers. */
   restHandlers: unknown[];
   flattenHandlers: FlattenHandler[];
   resetMSWDevTool: () => void;
@@ -20,6 +28,10 @@ export type HandlerStoreBaseState = {
   getHandlerCustomResponse: (id: string) => CustomResponse | undefined;
   setHandlerCustomResponse: (id: string, response: CustomResponse) => void;
   removeTempHandler: (id: string) => void;
+  webSocketEndpoints: ManagedWebSocketEndpoint[];
+  webSocketListeners: ManagedWebSocketListener[];
+  registerCodeWebSocketEndpoint: (endpoint: ManagedWebSocketEndpoint) => void;
+  registerCodeWebSocketListener: (listener: ManagedWebSocketListener) => void;
 };
 
 export type HandlerStoreInternalState<TRuntime extends MswDevToolRuntime> =

--- a/packages/core/src/shared/types/index.ts
+++ b/packages/core/src/shared/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./http";
 export * from "./msw";
 export * from "./utils";
+export * from "./websocket";
 export * from "./core";

--- a/packages/core/src/shared/types/websocket.ts
+++ b/packages/core/src/shared/types/websocket.ts
@@ -1,0 +1,17 @@
+export type ManagedWebSocketEndpoint = {
+  id: string;
+  endpoint: string;
+  source: "code";
+};
+
+export type ManagedWebSocketListener = {
+  id: string;
+  endpointId: string;
+  order: number;
+  event: "message";
+  source: "code";
+};
+
+export type ManagedWebSocketRegistration = {
+  endpoint: ManagedWebSocketEndpoint;
+};

--- a/packages/core/src/shared/websocket/bind.ts
+++ b/packages/core/src/shared/websocket/bind.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+import type {
+  ManagedWebSocketEndpoint,
+  ManagedWebSocketListener,
+} from "../types/websocket";
+
+export const WEBSOCKET_HANDLER_BIND = Symbol.for(
+  "@msw-dev-tool/core/websocket-handler-bind/v1"
+);
+
+export type WebSocketStoreAdapter = {
+  registerCodeWebSocketEndpoint(endpoint: ManagedWebSocketEndpoint): void;
+  registerCodeWebSocketListener(listener: ManagedWebSocketListener): void;
+};
+
+type WebSocketHandlerBindHook = {
+  bind(adapter: WebSocketStoreAdapter): void;
+  getAdapter(): WebSocketStoreAdapter | undefined;
+};
+
+const webSocketHandlerBindHookSchema = z.object({
+  bind: z.function(),
+});
+
+export const attachWebSocketHandlerBindHook = (
+  handler: object
+): WebSocketHandlerBindHook => {
+  let adapter: WebSocketStoreAdapter | undefined;
+  const hook: WebSocketHandlerBindHook = {
+    bind(nextAdapter) {
+      adapter = nextAdapter;
+    },
+    getAdapter: () => adapter,
+  };
+
+  Object.defineProperty(handler, WEBSOCKET_HANDLER_BIND, {
+    value: hook,
+  });
+  return hook;
+};
+
+export const bindWebSocketHandler = (
+  handler: unknown,
+  adapter: WebSocketStoreAdapter
+): boolean => {
+  if ((typeof handler !== "object" && typeof handler !== "function") || !handler) {
+    return false;
+  }
+  const hook = Reflect.get(handler, WEBSOCKET_HANDLER_BIND);
+  const result = webSocketHandlerBindHookSchema.safeParse(hook);
+  if (!result.success) {
+    return false;
+  }
+  result.data.bind(adapter);
+  return true;
+};

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -6,7 +6,11 @@ export default defineConfig({
       {
         test: {
           name: "shared-node",
-          include: ["src/shared/**/*.test.ts", "src/node/**/*.test.ts"],
+          include: [
+            "src/shared/**/*.test.ts",
+            "src/node/**/*.test.ts",
+            "src/msw/**/*.test.ts",
+          ],
           environment: "node",
         },
       },


### PR DESCRIPTION
## Abstract

Add an environment-neutral WebSocket wrapper that discovers code-defined endpoints and message listeners for the Dev Tool.

```mermaid
flowchart LR
  A[Code WebSocket handler] --> B[Dev Tool wrapper]
  B --> C[MSW runtime]
  C --> D[WebSocket connection]
  D --> E[Discover message listener]
  B --> F[Endpoint store]
  E --> F
```

## Issues

None.

## Description

- Export `@msw-dev-tool/core/msw` with a wrapped `ws` API.
- Register code-defined WebSocket endpoints and message listeners in browser and Node stores.
- Preserve accurate discovery metadata when the Dev Tool store resets.
- Cover wrapper discovery and reset behavior with core tests.

## Additional Context

Validated with:

- `yarn --cwd packages/core typecheck`
- `yarn --cwd packages/core lint`

The WebSocket Vitest integration file remains blocked in this environment while establishing its real socket connection, so its run did not reach a completion summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and tracking code-defined WebSocket endpoints and message listeners.
  * Added a public WebSocket integration for MSW, including endpoint and listener metadata.
  * WebSocket activity is now available through browser and Node handler stores.
* **Bug Fixes**
  * Prevented duplicate WebSocket registrations while preserving listener updates across connections.
* **Tests**
  * Added coverage for endpoint discovery, messaging, listener persistence, resets, and native WebSocket behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->