### PR TITLE
ci: upload coverage reports to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,8 @@ jobs:
 
       - name: Test
         run: yarn test:coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/browser-cli/vitest.config.mts
+++ b/packages/browser-cli/vitest.config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
-      reporter: ["text"],
+      reporter: ["text", "lcov"],
       thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
     },
   },

--- a/packages/cli-core/vitest.config.mts
+++ b/packages/cli-core/vitest.config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/types.ts"],
-      reporter: ["text"],
+      reporter: ["text", "lcov"],
       thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
     },
   },

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts"],
-      reporter: ["text"],
+      reporter: ["text", "lcov"],
       thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
     },
     projects: [

--- a/packages/node-cli/vitest.config.mts
+++ b/packages/node-cli/vitest.config.mts
@@ -9,7 +9,7 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
-      reporter: ["text"],
+      reporter: ["text", "lcov"],
       thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
     },
   },


### PR DESCRIPTION
## Abstract

Upload package test coverage to Codecov after CI coverage tests complete.

## Issues

None.

## Description

- Add the Codecov v5 upload action after `yarn test:coverage`.
- Generate LCOV reports for core, cli-core, node-cli, and browser-cli so Codecov can ingest coverage data.
- Authenticate the upload using the configured `CODECOV_TOKEN` secret.

## Additional Context

Validated with:

- `yarn test:coverage`
- `yarn typecheck`
- `yarn lint`