### PR TITLE
feat(core): add WebSocket handler state model

### DIFF
--- a/.changeset/websocket-state-model.md
+++ b/.changeset/websocket-state-model.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/core": minor
+---
+
+Add unified WebSocket endpoint and listener state management, lifecycle controls, and Browser/Node session persistence.

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -4,7 +4,7 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["dist/**", "node_modules/**"],
+    ignores: ["dist/**", "coverage/**", "node_modules/**"],
   },
   {
     files: ["src/**/*.{js,mjs,cjs,ts,tsx}"],

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -111,6 +111,69 @@ describe("browser control bridge", () => {
     });
   });
 
+  it("keeps HTTP temp metadata when hydrating WebSocket state", async () => {
+    await setupDevToolWorker(http.get("/hydrate", () => HttpResponse.json({ ok: true })));
+    const state = handlerStore.getState();
+    const endpointId = state.addTempWebSocketEndpoint({
+      endpoint: "ws://browser.test/temp",
+      matcher: { kind: "string", value: "ws://browser.test/temp" },
+    });
+    state.addTempHandler({
+      data: {
+        path: "/hydrate-temp",
+        method: "get",
+        contentType: "application/json",
+        status: "200",
+      },
+    });
+
+    expect(state.getHandlerInfo(endpointId)?.source).toBe("temp");
+    handlerStore.getState().hydrateWebSocket([]);
+
+    expect(handlerStore.getState().getHandlerInfo(endpointId)).toBeUndefined();
+    expect(handlerStore.getState().listHandlerInfo("http")).toEqual(
+      expect.arrayContaining([expect.objectContaining({ endpoint: "/hydrate-temp", source: "temp" })])
+    );
+    expect(handlerStore.getState().webSocketEndpoints).toEqual([]);
+  });
+
+  it("hydrates valid WebSocket state from sessionStorage", async () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({
+      state: {
+        flattenHandlers: [],
+        webSocket: [{
+          info: {
+            id: "websocket:endpoint:string:ws://browser.test/saved:0",
+            kind: "websocket",
+            endpoint: "ws://browser.test/saved",
+            operation: "endpoint",
+            source: "temp",
+          },
+          endpointId: "websocket:endpoint:string:ws://browser.test/saved:0",
+          matcher: { kind: "string", value: "ws://browser.test/saved" },
+          enabled: true,
+          listeners: [],
+        }],
+      },
+    }));
+
+    await setupDevToolWorker();
+
+    expect(handlerStore.getState().getWebSocketEndpoint("websocket:endpoint:string:ws://browser.test/saved:0")).toBeDefined();
+  });
+
+  it("ignores public snapshot assignments for closure-backed slices", async () => {
+    const chat = ws.link("ws://browser.test/closure");
+    await setupDevToolWorker(chat.addEventListener("connection", () => undefined));
+    const endpointId = handlerStore.getState().webSocket.endpoints[0]!.endpointId;
+    const before = handlerStore.getState().getWebSocketEndpoint(endpointId);
+
+    handlerStore.setState({ common: { handlers: [] }, webSocket: { endpoints: [], listeners: [] } });
+
+    expect(handlerStore.getState().common.handlers.length).toBeGreaterThan(0);
+    expect(handlerStore.getState().getWebSocketEndpoint(endpointId)).toEqual(before);
+  });
+
   it("maps direct object and functional updates to the base store", async () => {
     await setupDevToolWorker(http.get("/state", () => HttpResponse.json({ ok: true })));
     const initial = handlerStore.getState();

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -45,6 +45,8 @@ const mapState = (
   flattenHandlers: base.flattenHandlers,
   webSocketEndpoints: base.webSocketEndpoints,
   webSocketListeners: base.webSocketListeners,
+  common: base.common,
+  webSocket: base.webSocket,
   setupDevToolWorker,
   resetMSWDevTool: base.resetMSWDevTool,
   addTempHandler: base.addTempHandler,
@@ -57,6 +59,20 @@ const mapState = (
   removeTempHandler: base.removeTempHandler,
   registerCodeWebSocketEndpoint: base.registerCodeWebSocketEndpoint,
   registerCodeWebSocketListener: base.registerCodeWebSocketListener,
+  registerHandler: base.registerHandler,
+  unregisterHandler: base.unregisterHandler,
+  getHandlerInfo: base.getHandlerInfo,
+  listHandlerInfo: base.listHandlerInfo,
+  addTempWebSocketEndpoint: base.addTempWebSocketEndpoint,
+  addTempWebSocketListener: base.addTempWebSocketListener,
+  removeWebSocketEndpoint: base.removeWebSocketEndpoint,
+  removeWebSocketListener: base.removeWebSocketListener,
+  setWebSocketEndpointEnabled: base.setWebSocketEndpointEnabled,
+  setWebSocketListenerEnabled: base.setWebSocketListenerEnabled,
+  setWebSocketListenerBehavior: base.setWebSocketListenerBehavior,
+  hydrateWebSocket: base.hydrateWebSocket,
+  getWebSocketEndpoint: base.getWebSocketEndpoint,
+  getWebSocketListener: base.getWebSocketListener,
 });
 
 // Guard against SSR ReferenceError: sessionStorage is not defined.
@@ -91,9 +107,10 @@ const baseStore = createHandlerStore<SetupWorker>({
   persist: {
     name: STORAGE_KEY,
     partialize: (state) => ({
-      flattenHandlers: state.flattenHandlers.map(
+    flattenHandlers: state.flattenHandlers.map(
         ({ handler: _handler, ...rest }) => rest
       ),
+      webSocket: state.webSocket.endpoints,
     }),
     getStoredState: readBrowserPersistedState,
     write: writeBrowserPersistedState,
@@ -129,6 +146,8 @@ export const handlerStore: StoreApi<HandlerStoreState> = {
       basePartial.webSocketEndpoints = nextPartial.webSocketEndpoints;
     if ("webSocketListeners" in nextPartial)
       basePartial.webSocketListeners = nextPartial.webSocketListeners;
+    if ("common" in nextPartial) basePartial.common = nextPartial.common;
+    if ("webSocket" in nextPartial) basePartial.webSocket = nextPartial.webSocket;
 
     baseStore.setState(basePartial);
   },

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -147,8 +147,6 @@ export const handlerStore: StoreApi<HandlerStoreState> = {
       basePartial.webSocketEndpoints = nextPartial.webSocketEndpoints;
     if ("webSocketListeners" in nextPartial)
       basePartial.webSocketListeners = nextPartial.webSocketListeners;
-    if ("common" in nextPartial) basePartial.common = nextPartial.common;
-    if ("webSocket" in nextPartial) basePartial.webSocket = nextPartial.webSocket;
 
     baseStore.setState(basePartial);
   },

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -115,6 +115,7 @@ const baseStore = createHandlerStore<SetupWorker>({
     getStoredState: readBrowserPersistedState,
     write: writeBrowserPersistedState,
   },
+  getStoredWebSocketState: () => getBrowserStorageSnapshot().state.webSocket,
 });
 
 let cachedBase: HandlerStoreInternalState<SetupWorker> | null = null;

--- a/packages/core/src/browser/storage.ts
+++ b/packages/core/src/browser/storage.ts
@@ -8,8 +8,12 @@ import {
 } from "../shared/types";
 import { customResponseSchema, tempHandlerSchema } from "../shared/schema";
 import { mergeStorageData as mergeStorageDataPure } from "../shared/utils/storage";
+import type { JsonValue } from "../shared/types";
+import { webSocketEndpointsSchema } from "../shared/schema/websocket";
 
 export type BrowserStorageSnapshot = { revision: number; state: PersistedStorageData };
+
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValueSchema), z.record(jsonValueSchema)]));
 
 const persistedFlattenHandlerSchema = z.object({
   id: z.string(),
@@ -25,6 +29,7 @@ const browserStoragePayloadSchema = z.object({
   revision: z.number().optional(),
   state: z.object({
     flattenHandlers: z.array(persistedFlattenHandlerSchema),
+    webSocket: webSocketEndpointsSchema.optional(),
   }),
 });
 

--- a/packages/core/src/browser/storage.ts
+++ b/packages/core/src/browser/storage.ts
@@ -8,12 +8,9 @@ import {
 } from "../shared/types";
 import { customResponseSchema, tempHandlerSchema } from "../shared/schema";
 import { mergeStorageData as mergeStorageDataPure } from "../shared/utils/storage";
-import type { JsonValue } from "../shared/types";
 import { webSocketEndpointsSchema } from "../shared/schema/websocket";
 
 export type BrowserStorageSnapshot = { revision: number; state: PersistedStorageData };
-
-const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValueSchema), z.record(jsonValueSchema)]));
 
 const persistedFlattenHandlerSchema = z.object({
   id: z.string(),

--- a/packages/core/src/msw/websocket.test.ts
+++ b/packages/core/src/msw/websocket.test.ts
@@ -110,4 +110,22 @@ describe("wrapped ws", () => {
     expect(store.getState().webSocketListeners).toHaveLength(2);
   });
 
+  it("preserves RegExp matchers in the state model", async () => {
+    const regexp = /wrapper\.test\/regexp/i;
+    const endpoint = ws.link(regexp);
+    const handler = endpoint.addEventListener("connection", () => undefined);
+    const store = createHandlerStore<SetupServer>({
+      createRuntime: (handlers) => setupServer(...handlers),
+    });
+
+    const server = await store.getState().setupDevToolRuntime(handler);
+    servers.push(server);
+
+    expect(store.getState().webSocket.endpoints[0]?.matcher).toEqual({
+      kind: "regexp",
+      source: regexp.source,
+      flags: regexp.flags,
+    });
+  });
+
 });

--- a/packages/core/src/msw/websocket.ts
+++ b/packages/core/src/msw/websocket.ts
@@ -8,6 +8,7 @@ import {
   type WebSocketStoreAdapter,
 } from "../shared/websocket/bind";
 import type { ManagedWebSocketListener } from "../shared/types";
+import type { SerializableWebSocketMatcher } from "../shared/types";
 
 type WebSocketConnection = Parameters<WebSocketEventListener<"connection">>[0];
 type WebSocketClient = WebSocketConnection["client"];
@@ -18,6 +19,11 @@ type WebSocketClient = WebSocketConnection["client"];
  */
 const endpointFromMatcher = (matcher: string | RegExp): string =>
   typeof matcher === "string" ? matcher : `/${matcher.source}/${matcher.flags}`;
+
+const serializeMatcher = (matcher: string | RegExp): SerializableWebSocketMatcher =>
+  typeof matcher === "string"
+    ? { kind: "string", value: matcher }
+    : { kind: "regexp", source: matcher.source, flags: matcher.flags };
 
 const createProxyClient = (
   client: WebSocketClient,
@@ -105,6 +111,7 @@ const createWrappedLink = (
         id: endpointId,
         endpoint: endpointFromMatcher(matcher),
         source: "code" as const,
+        matcher: serializeMatcher(matcher),
       };
       const bind = hook.bind;
       hook.bind = (nextAdapter) => {

--- a/packages/core/src/node/handlerStore.ts
+++ b/packages/core/src/node/handlerStore.ts
@@ -25,6 +25,7 @@ const applyExternalSnapshot = (snapshot: SessionSnapshot): void => {
     snapshot,
   });
   baseStore.setState({ flattenHandlers });
+  if (snapshot.state.webSocket) baseStore.getState().hydrateWebSocket(snapshot.state.webSocket);
 };
 
 const resetFromCodeHandlers = (): FlattenHandler[] => {
@@ -49,10 +50,13 @@ export const setupDevToolServer = async (...handlers: Handler[]): Promise<SetupS
   const session = new SessionController({
     onSnapshot: applyExternalSnapshot,
     onReset: resetFromCodeHandlers,
+    onResetWebSocket: () => {
+      return baseStore.getState().webSocket.endpoints;
+    },
   });
 
   try {
-    await session.start(baseStore.getState().flattenHandlers);
+    await session.start(baseStore.getState().flattenHandlers, baseStore.getState().webSocket.endpoints);
     activeSession = session;
     return server;
   } catch (error) {

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -5,6 +5,7 @@ import { clearSessionArtifacts, ensureSessionPath } from "./sessionPath";
 import { bumpSnapshot, createEmptySnapshot, toSerializableFlattenHandlers } from "./serialize";
 import { SnapshotRepository } from "./repository";
 import { SessionSnapshot } from "./types";
+import type { WebSocketEndpointConfig } from "../../shared/types";
 
 const DEFAULT_POLL_INTERVAL_MS = 200;
 const WATCH_DEBOUNCE_MS = 25;
@@ -15,6 +16,7 @@ const isEnoent = (error: unknown): boolean =>
 export type SessionControllerOptions = {
   onSnapshot: (snapshot: SessionSnapshot) => void;
   onReset: () => FlattenHandler[];
+  onResetWebSocket?: () => WebSocketEndpointConfig[];
   pollIntervalMs?: number;
 };
 
@@ -40,7 +42,7 @@ export class SessionController {
     return this.repository?.sessionPath ?? null;
   }
 
-  public async start(flattenHandlers: FlattenHandler[]): Promise<void> {
+  public async start(flattenHandlers: FlattenHandler[], webSocket: WebSocketEndpointConfig[] = []): Promise<void> {
     const sessionPath = await ensureSessionPath();
     this.repository = new SnapshotRepository(sessionPath);
     this.cleanedUp = false;
@@ -49,7 +51,8 @@ export class SessionController {
 
     const seeded = await this.repository.mutate(() =>
       bumpSnapshot(createEmptySnapshot(), {
-        flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
+      flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
+      webSocket,
       })
     );
     this.lastWrittenRevision = seeded.revision;
@@ -90,10 +93,12 @@ export class SessionController {
 
     if (snapshot.state.pendingReset) {
       const flattenHandlers = this.options.onReset();
+      const webSocket = this.options.onResetWebSocket?.() ?? previousWebSocket(snapshot);
       const cleared = await repository.mutate((previous) => {
         if (!previous.state.pendingReset) return previous;
         return bumpSnapshot(previous, {
           flattenHandlers: toSerializableFlattenHandlers(flattenHandlers),
+          webSocket,
           pendingReset: false,
         });
       });
@@ -201,3 +206,5 @@ export class SessionController {
     this.signalHandlers.clear();
   }
 }
+
+const previousWebSocket = (snapshot: SessionSnapshot): WebSocketEndpointConfig[] => snapshot.state.webSocket ?? [];

--- a/packages/core/src/node/snapshot/serialize.ts
+++ b/packages/core/src/node/snapshot/serialize.ts
@@ -8,7 +8,7 @@ export const toSerializableFlattenHandlers = (
 
 export const createEmptySnapshot = (revision = 0): SessionSnapshot => ({
   revision,
-  state: { flattenHandlers: [] },
+  state: { flattenHandlers: [], webSocket: [] },
   owner: { pid: process.pid },
 });
 
@@ -27,6 +27,7 @@ export const bumpSnapshot = (
     revision: prev.revision + 1,
     state: {
       flattenHandlers: next.flattenHandlers ?? prev.state.flattenHandlers,
+      webSocket: next.webSocket ?? prev.state.webSocket,
       ...(pendingReset ? { pendingReset: true } : {}),
     },
     owner: prev.owner,

--- a/packages/core/src/node/snapshot/types.ts
+++ b/packages/core/src/node/snapshot/types.ts
@@ -3,7 +3,6 @@ import {
   HttpHandlerBehavior,
   HttpMethod,
 } from "../../shared/types";
-import type { WebSocketEndpointConfig } from "../../shared/types";
 import { webSocketEndpointsSchema } from "../../shared/schema/websocket";
 import { customResponseSchema, tempHandlerSchema } from "../../shared/schema";
 

--- a/packages/core/src/node/snapshot/types.ts
+++ b/packages/core/src/node/snapshot/types.ts
@@ -3,6 +3,8 @@ import {
   HttpHandlerBehavior,
   HttpMethod,
 } from "../../shared/types";
+import type { WebSocketEndpointConfig } from "../../shared/types";
+import { webSocketEndpointsSchema } from "../../shared/schema/websocket";
 import { customResponseSchema, tempHandlerSchema } from "../../shared/schema";
 
 export const tempHandlerInputSchema = tempHandlerSchema;
@@ -21,6 +23,7 @@ export const sessionSnapshotSchema = z.object({
   revision: z.number(),
   state: z.object({
     flattenHandlers: z.array(serializableFlattenHandlerSchema),
+    webSocket: webSocketEndpointsSchema.optional(),
     pendingReset: z.boolean().optional(),
   }),
   owner: z.object({ pid: z.number().int().nonnegative() }),

--- a/packages/core/src/shared/schema/index.ts
+++ b/packages/core/src/shared/schema/index.ts
@@ -26,3 +26,4 @@ export {
   isValidHandlerPath,
 } from "./handler";
 export type { TempHandlerSchema, HandlerSchema, CustomResponseSchema } from "./handler";
+export { webSocketEndpointsSchema, webSocketEndpointSchema, webSocketListenerSchema, serializableWebSocketMatcherSchema } from "./websocket";

--- a/packages/core/src/shared/schema/websocket.ts
+++ b/packages/core/src/shared/schema/websocket.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import type { JsonValue } from "../types";
+
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
+  z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValueSchema), z.record(jsonValueSchema),
+]));
+const webSocketInfoSchema = z.object({
+  id: z.string(), kind: z.literal("websocket"), endpoint: z.string(), operation: z.string(), source: z.enum(["code", "temp"]),
+});
+const webSocketBehaviorSchema = z.object({ preset: z.string(), options: jsonValueSchema.optional() });
+export const serializableWebSocketMatcherSchema = z.union([
+  z.object({ kind: z.literal("string"), value: z.string() }),
+  z.object({ kind: z.literal("regexp"), source: z.string(), flags: z.string() }),
+]);
+export const webSocketListenerSchema = z.object({
+  info: webSocketInfoSchema, endpointId: z.string(), event: z.literal("message"), enabled: z.boolean(), behavior: webSocketBehaviorSchema,
+});
+export const webSocketEndpointSchema = z.object({
+  info: webSocketInfoSchema, endpointId: z.string(), matcher: serializableWebSocketMatcherSchema, enabled: z.boolean(), listeners: z.array(webSocketListenerSchema),
+});
+export const webSocketEndpointsSchema = z.array(webSocketEndpointSchema);

--- a/packages/core/src/shared/schema/websocket.ts
+++ b/packages/core/src/shared/schema/websocket.ts
@@ -1,13 +1,8 @@
 import { z } from "zod";
-import type { JsonValue } from "../types";
-
-const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
-  z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValueSchema), z.record(jsonValueSchema),
-]));
 const webSocketInfoSchema = z.object({
   id: z.string(), kind: z.literal("websocket"), endpoint: z.string(), operation: z.string(), source: z.enum(["code", "temp"]),
 });
-const webSocketBehaviorSchema = z.object({ preset: z.string(), options: jsonValueSchema.optional() });
+const webSocketBehaviorSchema = z.object({ preset: z.string(), options: z.unknown().optional() });
 export const serializableWebSocketMatcherSchema = z.union([
   z.object({ kind: z.literal("string"), value: z.string() }),
   z.object({ kind: z.literal("regexp"), source: z.string(), flags: z.string() }),

--- a/packages/core/src/shared/store/commonSlice.ts
+++ b/packages/core/src/shared/store/commonSlice.ts
@@ -12,7 +12,9 @@ export const createHandlerRegistry = () => {
     unregisterHandler: (id: string) => { handlers = handlers.filter((entry) => entry.id !== id); },
     getHandlerInfo: (id: string) => handlers.find((entry) => entry.id === id),
     listHandlerInfo: (kind?: "http" | "websocket") => handlers.filter((entry) => !kind || entry.kind === kind),
-    clearTempHandlers: () => { handlers = handlers.filter((entry) => entry.source !== "temp"); },
+    clearTempHandlers: (kind?: "http" | "websocket") => {
+      handlers = handlers.filter((entry) => entry.source !== "temp" || (kind !== undefined && entry.kind !== kind));
+    },
     replace: (next: DevToolHandlerInfo[]) => { handlers = next; },
   };
 };

--- a/packages/core/src/shared/store/commonSlice.ts
+++ b/packages/core/src/shared/store/commonSlice.ts
@@ -1,0 +1,18 @@
+import type { DevToolHandlerInfo } from "../types";
+
+export type HandlerRegistryState = { handlers: DevToolHandlerInfo[] };
+
+export const createHandlerRegistry = () => {
+  let handlers: DevToolHandlerInfo[] = [];
+  return {
+    getState: (): HandlerRegistryState => ({ handlers }),
+    registerHandler: (info: DevToolHandlerInfo) => {
+      if (!handlers.some((entry) => entry.id === info.id)) handlers = [...handlers, info];
+    },
+    unregisterHandler: (id: string) => { handlers = handlers.filter((entry) => entry.id !== id); },
+    getHandlerInfo: (id: string) => handlers.find((entry) => entry.id === id),
+    listHandlerInfo: (kind?: "http" | "websocket") => handlers.filter((entry) => !kind || entry.kind === kind),
+    clearTempHandlers: () => { handlers = handlers.filter((entry) => entry.source !== "temp"); },
+    replace: (next: DevToolHandlerInfo[]) => { handlers = next; },
+  };
+};

--- a/packages/core/src/shared/store/createHandlerStore.test.ts
+++ b/packages/core/src/shared/store/createHandlerStore.test.ts
@@ -1,0 +1,78 @@
+import { setupServer, type SetupServer } from "msw/node";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHandlerStore } from "./createHandlerStore";
+
+const servers: SetupServer[] = [];
+
+afterEach(() => {
+  servers.splice(0).forEach((server) => server.close());
+});
+
+describe("createHandlerStore WebSocket coordination", () => {
+  it("coordinates temporary lifecycle and direct code registration", async () => {
+    const runtime = {
+      addTempEndpoint: vi.fn(),
+      removeEndpoint: vi.fn(),
+      closeEndpointConnections: vi.fn(),
+      resetTempEndpoints: vi.fn(),
+    };
+    const store = createHandlerStore<SetupServer>({
+      createRuntime: (handlers) => {
+        const server = setupServer(...handlers);
+        servers.push(server);
+        return server;
+      },
+      webSocketRuntime: runtime,
+    });
+    await store.getState().setupDevToolRuntime();
+
+    store.getState().registerCodeWebSocketEndpoint({
+      id: "manual-endpoint",
+      endpoint: "ws://manual.test",
+      source: "code",
+    });
+    store.getState().registerCodeWebSocketListener({
+      id: "orphan-listener",
+      endpointId: "missing-endpoint",
+      order: 0,
+      event: "message",
+      source: "code",
+    });
+
+    const endpointId = store.getState().addTempWebSocketEndpoint({
+      endpoint: "ws://temp.test",
+      matcher: { kind: "string", value: "ws://temp.test" },
+    });
+    const listenerId = store.getState().addTempWebSocketListener({
+      endpointId,
+      behavior: { preset: "reply" },
+    });
+    store.getState().setWebSocketEndpointEnabled(endpointId, true);
+    store.getState().setWebSocketEndpointEnabled(endpointId, false);
+    store.getState().setWebSocketListenerEnabled(listenerId, false);
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "drop" });
+    store.getState().removeWebSocketListener(listenerId);
+    store.getState().removeWebSocketEndpoint(endpointId);
+
+    expect(store.getState().getHandlerInfo("orphan-listener")).toMatchObject({
+      endpoint: "missing-endpoint",
+    });
+    expect(runtime.addTempEndpoint).toHaveBeenCalledOnce();
+    expect(runtime.closeEndpointConnections).toHaveBeenCalledWith(endpointId);
+    expect(runtime.removeEndpoint).toHaveBeenCalledWith(endpointId);
+  });
+
+  it("rejects malformed persisted WebSocket state at the store boundary", async () => {
+    let runtime: SetupServer | undefined;
+    const store = createHandlerStore<SetupServer>({
+      createRuntime: (handlers) => {
+        runtime = setupServer(...handlers);
+        return runtime;
+      },
+      getStoredWebSocketState: () => ({ invalid: true }),
+    });
+
+    await expect(store.getState().setupDevToolRuntime()).rejects.toThrow();
+    runtime?.close();
+  });
+});

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -16,6 +16,12 @@ import {
 } from "../types";
 import { initMSWDevToolStore } from "../utils";
 import { bindWebSocketHandler } from "../websocket/bind";
+import { createHandlerRegistry } from "./commonSlice";
+import {
+  createWebSocketSlice,
+  managedEndpointToInfo,
+  managedListenerToInfo,
+} from "./webSocketSlice";
 import { createStore, StoreApi } from "./createStore";
 import {
   CreateHandlerStoreOptions,
@@ -47,6 +53,26 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
 ): StoreApi<HandlerStoreInternalState<TRuntime>> => {
   const store = createStore<HandlerStoreInternalState<TRuntime>>(
     (set, get) => {
+      const registry = createHandlerRegistry();
+      const webSocketSlice = createWebSocketSlice(options.webSocketRuntime);
+      const syncWebSocketState = (extra: Partial<HandlerStoreInternalState<TRuntime>> = {}) => {
+        const webSocket = webSocketSlice.getState();
+        set({ ...extra,
+          common: registry.getState(),
+          webSocket,
+          webSocketEndpoints: webSocket.endpoints.map((entry) => ({ id: entry.endpointId, endpoint: entry.info.endpoint, source: entry.info.source === "code" ? "code" : "code" })),
+          webSocketListeners: webSocket.listeners.map((entry, order) => ({ id: entry.info.id, endpointId: entry.endpointId, order, event: entry.event, source: entry.info.source === "code" ? "code" : "code" })),
+        });
+      };
+      const registerHttpHandlers = (handlers: FlattenHandler[]) => {
+        handlers.forEach((handler) => registry.registerHandler({
+          id: handler.id,
+          kind: "http",
+          endpoint: handler.path,
+          operation: handler.method,
+          source: handler.type === "temp" ? "temp" : "code",
+        }));
+      };
       const lookupBehavior = (id: string) =>
         findHandlerBehavior(get().flattenHandlers, id);
       const lookupCustomResponse = (id: string) =>
@@ -54,14 +80,24 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
 
       const bindWebSocketHandlers = (handlers: readonly unknown[]) => {
         const adapter = {
-          registerCodeWebSocketEndpoint: get().registerCodeWebSocketEndpoint,
-          registerCodeWebSocketListener: get().registerCodeWebSocketListener,
+          registerCodeWebSocketEndpoint: (endpoint: import("../types").ManagedWebSocketEndpoint) => {
+            webSocketSlice.registerCodeEndpoint({ info: managedEndpointToInfo(endpoint), matcher: { kind: "string", value: endpoint.endpoint } });
+            registry.registerHandler(managedEndpointToInfo(endpoint));
+            syncWebSocketState();
+          },
+          registerCodeWebSocketListener: (listener: import("../types").ManagedWebSocketListener) => {
+            webSocketSlice.registerCodeListener({ info: managedListenerToInfo(listener), endpointId: listener.endpointId, event: listener.event });
+            registry.registerHandler(managedListenerToInfo(listener));
+            syncWebSocketState();
+          },
         };
         handlers.forEach((handler) => bindWebSocketHandler(handler, adapter));
       };
 
       return {
         flattenHandlers: [],
+        common: registry.getState(),
+        webSocket: webSocketSlice.getState(),
         runtime: null,
         restHandlers: [],
         webSocketEndpoints: [],
@@ -105,7 +141,17 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             webSocketEndpoints: [],
             webSocketListeners: [],
           });
+          webSocketSlice.replace([]);
+          registry.replace([]);
+          registerHttpHandlers(rehydratedHandlers);
           bindWebSocketHandlers(handlers);
+          const persisted = options.persist?.getStoredState()?.webSocket as unknown as import("../types").WebSocketEndpointConfig[] | undefined;
+          if (persisted) {
+            webSocketSlice.hydrate(persisted);
+            persisted.flatMap((entry) => entry.listeners).forEach((listener) => registry.registerHandler(listener.info));
+            persisted.forEach((entry) => registry.registerHandler(entry.info));
+          }
+          syncWebSocketState();
 
           return runtime;
         },
@@ -116,14 +162,11 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           const { flattenHandlers, unsupportedHandlers } =
             initMSWDevToolStore(runtime);
 
-          set({
-            runtime,
-            flattenHandlers,
-            restHandlers: unsupportedHandlers,
-            webSocketEndpoints: [],
-            webSocketListeners: [],
-          });
+          webSocketSlice.reset();
+          registry.replace(registry.getState().handlers.filter((entry) => entry.source === "code"));
+          registerHttpHandlers(flattenHandlers);
           bindWebSocketHandlers(runtime.listHandlers());
+          syncWebSocketState({ runtime, flattenHandlers, restHandlers: unsupportedHandlers });
         },
         addTempHandler: ({ data }) => {
           const { handler, flattenHandler } = buildTempHandler(
@@ -138,10 +181,8 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           );
           runtime.use(handler);
 
-          set({
-            runtime,
-            flattenHandlers,
-          });
+          registry.registerHandler({ id: flattenHandler.id, kind: "http", endpoint: flattenHandler.path, operation: flattenHandler.method, source: "temp" });
+          syncWebSocketState({ runtime, flattenHandlers });
         },
         getRuntime: () => {
           const runtime = get().runtime;
@@ -182,37 +223,33 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           runtime.resetHandlers();
           registerTempHandlers(runtime, flattenHandlers);
 
-          set({
-            runtime,
-            flattenHandlers,
-          });
+          registry.unregisterHandler(id);
+          syncWebSocketState({ runtime, flattenHandlers });
         },
         registerCodeWebSocketEndpoint: (endpoint) => {
-          if (
-            get().webSocketEndpoints.some(
-              (current) => current.id === endpoint.id
-            )
-          ) {
-            return;
-          }
-
-          set({
-            webSocketEndpoints: [...get().webSocketEndpoints, endpoint],
-          });
+          webSocketSlice.registerCodeEndpoint({ info: managedEndpointToInfo(endpoint), matcher: { kind: "string", value: endpoint.endpoint } });
+          registry.registerHandler(managedEndpointToInfo(endpoint));
+          syncWebSocketState();
         },
         registerCodeWebSocketListener: (listener) => {
-          if (
-            get().webSocketListeners.some(
-              (current) => current.id === listener.id
-            )
-          ) {
-            return;
-          }
-
-          set({
-            webSocketListeners: [...get().webSocketListeners, listener],
-          });
+          webSocketSlice.registerCodeListener({ info: managedListenerToInfo(listener), endpointId: listener.endpointId, event: listener.event });
+          registry.registerHandler(managedListenerToInfo(listener));
+          syncWebSocketState();
         },
+        registerHandler: (info) => { registry.registerHandler(info); syncWebSocketState(); },
+        unregisterHandler: (id) => { registry.unregisterHandler(id); syncWebSocketState(); },
+        getHandlerInfo: (id) => registry.getHandlerInfo(id),
+        listHandlerInfo: (kind) => registry.listHandlerInfo(kind),
+        addTempWebSocketEndpoint: (input) => { const id = webSocketSlice.addTempEndpoint(input); const info = webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === id)?.info; if (info) registry.registerHandler(info); syncWebSocketState(); return id; },
+        addTempWebSocketListener: (input) => { const id = webSocketSlice.addTempListener(input); const info = webSocketSlice.getState().listeners.find((entry) => entry.info.id === id)?.info; if (info) registry.registerHandler(info); syncWebSocketState(); return id; },
+        removeWebSocketEndpoint: (id) => { const endpoint = webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === id); webSocketSlice.removeEndpoint(id); if (endpoint) { registry.unregisterHandler(id); endpoint.listeners.forEach((listener) => registry.unregisterHandler(listener.info.id)); } syncWebSocketState(); },
+        removeWebSocketListener: (id) => { webSocketSlice.removeListener(id); registry.unregisterHandler(id); syncWebSocketState(); },
+        setWebSocketEndpointEnabled: (id, enabled) => { webSocketSlice.setEndpointEnabled(id, enabled); syncWebSocketState(); },
+        setWebSocketListenerEnabled: (id, enabled) => { webSocketSlice.setListenerEnabled(id, enabled); syncWebSocketState(); },
+        setWebSocketListenerBehavior: (id, behavior) => { webSocketSlice.setListenerBehavior(id, behavior); syncWebSocketState(); },
+        hydrateWebSocket: (endpoints) => { webSocketSlice.hydrate(endpoints); endpoints.forEach((endpoint) => { registry.registerHandler(endpoint.info); endpoint.listeners.forEach((listener) => registry.registerHandler(listener.info)); }); syncWebSocketState(); },
+        getWebSocketEndpoint: (id) => webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === id),
+        getWebSocketListener: (id) => webSocketSlice.getState().listeners.find((entry) => entry.info.id === id),
       };
     },
     options.persist

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -81,7 +81,7 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
       const bindWebSocketHandlers = (handlers: readonly unknown[]) => {
         const adapter = {
           registerCodeWebSocketEndpoint: (endpoint: import("../types").ManagedWebSocketEndpoint) => {
-            webSocketSlice.registerCodeEndpoint({ info: managedEndpointToInfo(endpoint), matcher: { kind: "string", value: endpoint.endpoint } });
+            webSocketSlice.registerCodeEndpoint({ info: managedEndpointToInfo(endpoint), matcher: endpoint.matcher ?? { kind: "string", value: endpoint.endpoint } });
             registry.registerHandler(managedEndpointToInfo(endpoint));
             syncWebSocketState();
           },
@@ -227,7 +227,7 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           syncWebSocketState({ runtime, flattenHandlers });
         },
         registerCodeWebSocketEndpoint: (endpoint) => {
-          webSocketSlice.registerCodeEndpoint({ info: managedEndpointToInfo(endpoint), matcher: { kind: "string", value: endpoint.endpoint } });
+          webSocketSlice.registerCodeEndpoint({ info: managedEndpointToInfo(endpoint), matcher: endpoint.matcher ?? { kind: "string", value: endpoint.endpoint } });
           registry.registerHandler(managedEndpointToInfo(endpoint));
           syncWebSocketState();
         },

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -16,6 +16,7 @@ import {
 } from "../types";
 import { initMSWDevToolStore } from "../utils";
 import { bindWebSocketHandler } from "../websocket/bind";
+import { webSocketEndpointsSchema } from "../schema/websocket";
 import { createHandlerRegistry } from "./commonSlice";
 import {
   createWebSocketSlice,
@@ -60,8 +61,8 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
         set({ ...extra,
           common: registry.getState(),
           webSocket,
-          webSocketEndpoints: webSocket.endpoints.map((entry) => ({ id: entry.endpointId, endpoint: entry.info.endpoint, source: entry.info.source === "code" ? "code" : "code" })),
-          webSocketListeners: webSocket.listeners.map((entry, order) => ({ id: entry.info.id, endpointId: entry.endpointId, order, event: entry.event, source: entry.info.source === "code" ? "code" : "code" })),
+          webSocketEndpoints: webSocket.endpoints.filter((entry) => entry.info.source === "code").map((entry) => ({ id: entry.endpointId, endpoint: entry.info.endpoint, source: "code" as const })),
+          webSocketListeners: webSocket.listeners.filter((entry) => entry.info.source === "code").map((entry, order) => ({ id: entry.info.id, endpointId: entry.endpointId, order, event: entry.event, source: "code" as const })),
         });
       };
       const registerHttpHandlers = (handlers: FlattenHandler[]) => {
@@ -86,8 +87,10 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             syncWebSocketState();
           },
           registerCodeWebSocketListener: (listener: import("../types").ManagedWebSocketListener) => {
-            webSocketSlice.registerCodeListener({ info: managedListenerToInfo(listener), endpointId: listener.endpointId, event: listener.event });
-            registry.registerHandler(managedListenerToInfo(listener));
+            const endpoint = webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === listener.endpointId);
+            const info = managedListenerToInfo(listener, endpoint?.info.endpoint);
+            webSocketSlice.registerCodeListener({ info, endpointId: listener.endpointId, event: listener.event });
+            registry.registerHandler(info);
             syncWebSocketState();
           },
         };
@@ -134,6 +137,11 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             flattenHandlers: rehydratedHandlers,
           });
 
+          const persistedValue = options.getStoredWebSocketState?.();
+          const persisted = persistedValue === undefined
+            ? undefined
+            : webSocketEndpointsSchema.parse(persistedValue);
+
           set({
             runtime,
             flattenHandlers: rehydratedHandlers,
@@ -145,11 +153,11 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           registry.replace([]);
           registerHttpHandlers(rehydratedHandlers);
           bindWebSocketHandlers(handlers);
-          const persisted = options.getStoredWebSocketState?.();
           if (persisted) {
             webSocketSlice.hydrate(persisted);
-            persisted.flatMap((entry) => entry.listeners).forEach((listener) => registry.registerHandler(listener.info));
-            persisted.forEach((entry) => registry.registerHandler(entry.info));
+            const hydrated = webSocketSlice.getState();
+            hydrated.endpoints.flatMap((entry) => [entry.info, ...entry.listeners.map((listener) => listener.info)])
+              .forEach((info) => registry.registerHandler(info));
           }
           syncWebSocketState();
 
@@ -232,8 +240,10 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           syncWebSocketState();
         },
         registerCodeWebSocketListener: (listener) => {
-          webSocketSlice.registerCodeListener({ info: managedListenerToInfo(listener), endpointId: listener.endpointId, event: listener.event });
-          registry.registerHandler(managedListenerToInfo(listener));
+          const endpoint = webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === listener.endpointId);
+          const info = managedListenerToInfo(listener, endpoint?.info.endpoint);
+          webSocketSlice.registerCodeListener({ info, endpointId: listener.endpointId, event: listener.event });
+          registry.registerHandler(info);
           syncWebSocketState();
         },
         registerHandler: (info) => { registry.registerHandler(info); syncWebSocketState(); },
@@ -247,7 +257,14 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
         setWebSocketEndpointEnabled: (id, enabled) => { webSocketSlice.setEndpointEnabled(id, enabled); syncWebSocketState(); },
         setWebSocketListenerEnabled: (id, enabled) => { webSocketSlice.setListenerEnabled(id, enabled); syncWebSocketState(); },
         setWebSocketListenerBehavior: (id, behavior) => { webSocketSlice.setListenerBehavior(id, behavior); syncWebSocketState(); },
-        hydrateWebSocket: (endpoints) => { webSocketSlice.hydrate(endpoints); endpoints.forEach((endpoint) => { registry.registerHandler(endpoint.info); endpoint.listeners.forEach((listener) => registry.registerHandler(listener.info)); }); syncWebSocketState(); },
+        hydrateWebSocket: (endpoints) => {
+          registry.clearTempHandlers("websocket");
+          webSocketSlice.hydrate(endpoints);
+          const hydrated = webSocketSlice.getState();
+          hydrated.endpoints.flatMap((entry) => [entry.info, ...entry.listeners.map((listener) => listener.info)])
+            .forEach((info) => registry.registerHandler(info));
+          syncWebSocketState();
+        },
         getWebSocketEndpoint: (id) => webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === id),
         getWebSocketListener: (id) => webSocketSlice.getState().listeners.find((entry) => entry.info.id === id),
       };

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -145,7 +145,7 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           registry.replace([]);
           registerHttpHandlers(rehydratedHandlers);
           bindWebSocketHandlers(handlers);
-          const persisted = options.persist?.getStoredState()?.webSocket as unknown as import("../types").WebSocketEndpointConfig[] | undefined;
+          const persisted = options.getStoredWebSocketState?.();
           if (persisted) {
             webSocketSlice.hydrate(persisted);
             persisted.flatMap((entry) => entry.listeners).forEach((listener) => registry.registerHandler(listener.info));

--- a/packages/core/src/shared/store/index.ts
+++ b/packages/core/src/shared/store/index.ts
@@ -1,3 +1,5 @@
 export * from "./createStore";
 export * from "./createHandlerStore";
 export * from "./types";
+export * from "./commonSlice";
+export * from "./webSocketSlice";

--- a/packages/core/src/shared/store/types.ts
+++ b/packages/core/src/shared/store/types.ts
@@ -5,11 +5,16 @@ import {
   HttpHandlerBehavior,
   ManagedWebSocketEndpoint,
   ManagedWebSocketListener,
+  DevToolHandlerInfo,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
   TempHandlerInput,
 } from "../types";
 import type { HydratableFlattenHandler } from "../utils/storage";
 import { ListHandlersRuntime } from "../utils";
 import { PersistOptions, StoreApi } from "./createStore";
+import type { HandlerRegistryState } from "./commonSlice";
+import type { WebSocketRuntimeAdapter, WebSocketStoreState } from "./webSocketSlice";
 
 export type MswDevToolRuntime = ListHandlersRuntime & {
   use: (...handlers: Handler[]) => void;
@@ -17,6 +22,8 @@ export type MswDevToolRuntime = ListHandlersRuntime & {
 };
 
 export type HandlerStoreBaseState = {
+  common: HandlerRegistryState;
+  webSocket: WebSocketStoreState;
   /** GraphQL handlers and unsupported handlers. */
   restHandlers: unknown[];
   flattenHandlers: FlattenHandler[];
@@ -32,6 +39,20 @@ export type HandlerStoreBaseState = {
   webSocketListeners: ManagedWebSocketListener[];
   registerCodeWebSocketEndpoint: (endpoint: ManagedWebSocketEndpoint) => void;
   registerCodeWebSocketListener: (listener: ManagedWebSocketListener) => void;
+  registerHandler: (info: DevToolHandlerInfo) => void;
+  unregisterHandler: (id: string) => void;
+  getHandlerInfo: (id: string) => DevToolHandlerInfo | undefined;
+  listHandlerInfo: (kind?: "http" | "websocket") => DevToolHandlerInfo[];
+  addTempWebSocketEndpoint: (input: { matcher: WebSocketEndpointConfig["matcher"]; endpoint: string }) => string;
+  addTempWebSocketListener: (input: { endpointId: string; behavior: WebSocketBehaviorSelection }) => string;
+  removeWebSocketEndpoint: (endpointId: string) => void;
+  removeWebSocketListener: (listenerId: string) => void;
+  setWebSocketEndpointEnabled: (endpointId: string, enabled: boolean) => void;
+  setWebSocketListenerEnabled: (listenerId: string, enabled: boolean) => void;
+  setWebSocketListenerBehavior: (listenerId: string, behavior: WebSocketBehaviorSelection) => void;
+  hydrateWebSocket: (endpoints: WebSocketEndpointConfig[]) => void;
+  getWebSocketEndpoint: (endpointId: string) => WebSocketEndpointConfig | undefined;
+  getWebSocketListener: (listenerId: string) => WebSocketEndpointConfig["listeners"][number] | undefined;
 };
 
 export type HandlerStoreInternalState<TRuntime extends MswDevToolRuntime> =
@@ -50,6 +71,7 @@ export type CreateHandlerStoreOptions<TRuntime extends MswDevToolRuntime> = {
   }) => HydratableFlattenHandler[];
   onSetup?: (args: { runtime: TRuntime; flattenHandlers: FlattenHandler[] }) => void;
   persist?: PersistOptions<HandlerStoreInternalState<TRuntime>>;
+  webSocketRuntime?: WebSocketRuntimeAdapter;
 };
 
 export type HandlerStoreApi<TRuntime extends MswDevToolRuntime> = StoreApi<

--- a/packages/core/src/shared/store/types.ts
+++ b/packages/core/src/shared/store/types.ts
@@ -72,6 +72,7 @@ export type CreateHandlerStoreOptions<TRuntime extends MswDevToolRuntime> = {
   onSetup?: (args: { runtime: TRuntime; flattenHandlers: FlattenHandler[] }) => void;
   persist?: PersistOptions<HandlerStoreInternalState<TRuntime>>;
   webSocketRuntime?: WebSocketRuntimeAdapter;
+  getStoredWebSocketState?: () => WebSocketEndpointConfig[] | undefined;
 };
 
 export type HandlerStoreApi<TRuntime extends MswDevToolRuntime> = StoreApi<

--- a/packages/core/src/shared/store/types.ts
+++ b/packages/core/src/shared/store/types.ts
@@ -72,7 +72,7 @@ export type CreateHandlerStoreOptions<TRuntime extends MswDevToolRuntime> = {
   onSetup?: (args: { runtime: TRuntime; flattenHandlers: FlattenHandler[] }) => void;
   persist?: PersistOptions<HandlerStoreInternalState<TRuntime>>;
   webSocketRuntime?: WebSocketRuntimeAdapter;
-  getStoredWebSocketState?: () => WebSocketEndpointConfig[] | undefined;
+  getStoredWebSocketState?: () => unknown;
 };
 
 export type HandlerStoreApi<TRuntime extends MswDevToolRuntime> = StoreApi<

--- a/packages/core/src/shared/store/webSocketSlice.test.ts
+++ b/packages/core/src/shared/store/webSocketSlice.test.ts
@@ -92,6 +92,35 @@ describe("WebSocket state model", () => {
     slice.reset();
     expect(slice.getState().endpoints.map((entry) => entry.info.id)).toEqual([codeInfo.id]);
   });
+
+  it("avoids endpoint ID collisions after hydrating temporary state", () => {
+    const slice = createWebSocketSlice();
+    const matcher = { kind: "string" as const, value: "ws://example.test/temp" };
+    const first = slice.addTempEndpoint({ endpoint: matcher.value, matcher });
+    const saved = slice.getState().endpoints;
+    slice.replace([]);
+    slice.hydrate(saved);
+
+    const second = slice.addTempEndpoint({ endpoint: matcher.value, matcher });
+
+    expect(second).not.toBe(first);
+    expect(slice.getState().endpoints).toHaveLength(2);
+  });
+
+  it("allocates a fresh listener ID after an earlier listener is removed", () => {
+    const slice = createWebSocketSlice();
+    const endpointId = slice.addTempEndpoint({
+      endpoint: "ws://example.test/temp",
+      matcher: { kind: "string", value: "temp" },
+    });
+    const first = slice.addTempListener({ endpointId, behavior: { preset: "one" } });
+    const second = slice.addTempListener({ endpointId, behavior: { preset: "two" } });
+    slice.removeListener(first);
+    const third = slice.addTempListener({ endpointId, behavior: { preset: "three" } });
+
+    expect(third).not.toBe(second);
+    expect(slice.getState().listeners.map((entry) => entry.info.id)).toEqual([second, third]);
+  });
 });
 
 describe("handler registry", () => {

--- a/packages/core/src/shared/store/webSocketSlice.test.ts
+++ b/packages/core/src/shared/store/webSocketSlice.test.ts
@@ -93,6 +93,40 @@ describe("WebSocket state model", () => {
     expect(slice.getState().endpoints.map((entry) => entry.info.id)).toEqual([codeInfo.id]);
   });
 
+  it("rejects orphan listeners and supports enabling code endpoints", () => {
+    const slice = createWebSocketSlice();
+    expect(() => slice.addTempListener({ endpointId: "missing", behavior: { preset: "reply" } })).toThrow("not found");
+    expect(() => slice.removeEndpoint("missing")).toThrow("not found");
+    expect(() => slice.setEndpointEnabled("missing", true)).toThrow("not found");
+    expect(() => slice.setListenerEnabled("missing", true)).toThrow("not found");
+    expect(() => slice.setListenerBehavior("missing", { preset: "reply" })).toThrow("not found");
+    slice.registerCodeListener({
+      info: {
+        id: "orphan",
+        kind: "websocket",
+        endpoint: "ws://example.test",
+        operation: "message",
+        source: "code",
+      },
+      endpointId: "missing",
+      event: "message",
+    });
+    expect(slice.getState().listeners).toHaveLength(0);
+
+    slice.registerCodeEndpoint({
+      info: {
+        id: "code-enabled",
+        kind: "websocket",
+        endpoint: "ws://example.test",
+        operation: "endpoint",
+        source: "code",
+      },
+      matcher: { kind: "string", value: "ws://example.test" },
+    });
+    slice.setEndpointEnabled("code-enabled", true);
+    expect(slice.getState().endpoints[0]?.enabled).toBe(true);
+  });
+
   it("avoids endpoint ID collisions after hydrating temporary state", () => {
     const slice = createWebSocketSlice();
     const matcher = { kind: "string" as const, value: "ws://example.test/temp" };
@@ -130,6 +164,10 @@ describe("handler registry", () => {
     registry.registerHandler({ id: "ws", kind: "websocket", endpoint: "ws://example.test", operation: "endpoint", source: "temp" });
 
     expect(registry.listHandlerInfo("websocket")).toHaveLength(1);
+    registry.clearTempHandlers("websocket");
+    expect(registry.listHandlerInfo("http")).toHaveLength(1);
+    expect(registry.listHandlerInfo("websocket")).toHaveLength(0);
+    registry.registerHandler({ id: "ws-again", kind: "websocket", endpoint: "ws://example.test", operation: "endpoint", source: "temp" });
     registry.clearTempHandlers();
     expect(registry.listHandlerInfo()).toEqual([
       { id: "http", kind: "http", endpoint: "/users", operation: "get", source: "code" },

--- a/packages/core/src/shared/store/webSocketSlice.test.ts
+++ b/packages/core/src/shared/store/webSocketSlice.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHandlerRegistry } from "./commonSlice";
+import { createWebSocketSlice } from "./webSocketSlice";
+
+describe("WebSocket state model", () => {
+  it("registers code hierarchy and prevents duplicate discovery", () => {
+    const slice = createWebSocketSlice();
+    const info = {
+      id: "code-endpoint",
+      kind: "websocket" as const,
+      endpoint: "ws://example.test/chat",
+      operation: "endpoint",
+      source: "code" as const,
+    };
+
+    slice.registerCodeEndpoint({
+      info,
+      matcher: { kind: "regexp", source: "^chat$", flags: "i" },
+    });
+    slice.registerCodeEndpoint({
+      info,
+      matcher: { kind: "string", value: "different" },
+    });
+    slice.registerCodeListener({
+      info: { ...info, id: "code-listener", operation: "message" },
+      endpointId: info.id,
+      event: "message",
+    });
+    slice.registerCodeListener({
+      info: { ...info, id: "code-listener", operation: "message" },
+      endpointId: info.id,
+      event: "message",
+    });
+
+    expect(slice.getState().endpoints).toHaveLength(1);
+    expect(slice.getState().endpoints[0]?.matcher).toEqual({
+      kind: "regexp",
+      source: "^chat$",
+      flags: "i",
+    });
+    expect(slice.getState().listeners).toHaveLength(1);
+  });
+
+  it("manages temporary lifecycle, behavior, enabled state, and runtime cleanup", () => {
+    const runtime = {
+      addTempEndpoint: vi.fn(),
+      removeEndpoint: vi.fn(),
+      closeEndpointConnections: vi.fn(),
+      resetTempEndpoints: vi.fn(),
+    };
+    const slice = createWebSocketSlice(runtime);
+    const endpointId = slice.addTempEndpoint({
+      endpoint: "ws://example.test/temp",
+      matcher: { kind: "string", value: "ws://example.test/temp" },
+    });
+    const listenerId = slice.addTempListener({
+      endpointId,
+      behavior: { preset: "reply", options: { body: "ok" } },
+    });
+
+    slice.setEndpointEnabled(endpointId, false);
+    slice.setListenerEnabled(listenerId, false);
+    slice.setListenerBehavior(listenerId, { preset: "drop" });
+
+    expect(slice.getState().endpoints[0]).toMatchObject({ endpointId, enabled: false });
+    expect(slice.getState().listeners[0]).toMatchObject({
+      info: { id: listenerId, source: "temp" },
+      enabled: false,
+      behavior: { preset: "drop" },
+    });
+    expect(runtime.addTempEndpoint).toHaveBeenCalledOnce();
+    expect(runtime.closeEndpointConnections).toHaveBeenCalledWith(endpointId);
+
+    slice.removeEndpoint(endpointId);
+    expect(slice.getState()).toEqual({ endpoints: [], listeners: [] });
+    expect(runtime.removeEndpoint).toHaveBeenCalledWith(endpointId);
+  });
+
+  it("keeps code entries on reset and rejects deleting them", () => {
+    const slice = createWebSocketSlice();
+    const codeInfo = {
+      id: "code",
+      kind: "websocket" as const,
+      endpoint: "ws://example.test/code",
+      operation: "endpoint",
+      source: "code" as const,
+    };
+    slice.registerCodeEndpoint({ info: codeInfo, matcher: { kind: "string", value: codeInfo.endpoint } });
+    expect(() => slice.removeEndpoint(codeInfo.id)).toThrow("cannot be deleted");
+
+    slice.addTempEndpoint({ endpoint: "ws://example.test/temp", matcher: { kind: "string", value: "temp" } });
+    slice.reset();
+    expect(slice.getState().endpoints.map((entry) => entry.info.id)).toEqual([codeInfo.id]);
+  });
+});
+
+describe("handler registry", () => {
+  it("filters metadata and clears temporary entries", () => {
+    const registry = createHandlerRegistry();
+    registry.registerHandler({ id: "http", kind: "http", endpoint: "/users", operation: "get", source: "code" });
+    registry.registerHandler({ id: "ws", kind: "websocket", endpoint: "ws://example.test", operation: "endpoint", source: "temp" });
+
+    expect(registry.listHandlerInfo("websocket")).toHaveLength(1);
+    registry.clearTempHandlers();
+    expect(registry.listHandlerInfo()).toEqual([
+      { id: "http", kind: "http", endpoint: "/users", operation: "get", source: "code" },
+    ]);
+  });
+});

--- a/packages/core/src/shared/store/webSocketSlice.ts
+++ b/packages/core/src/shared/store/webSocketSlice.ts
@@ -1,0 +1,135 @@
+import type {
+  DevToolHandlerInfo,
+  ManagedWebSocketEndpoint,
+  ManagedWebSocketListener,
+  SerializableWebSocketMatcher,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
+  WebSocketListenerConfig,
+  WebSocketHandlerInfo,
+} from "../types";
+
+export type WebSocketRuntimeAdapter = {
+  addTempEndpoint?: (config: WebSocketEndpointConfig) => void;
+  removeEndpoint?: (endpointId: string) => void;
+  closeEndpointConnections?: (endpointId: string) => void;
+  resetTempEndpoints?: () => void;
+};
+
+export type WebSocketStoreState = {
+  endpoints: WebSocketEndpointConfig[];
+  listeners: WebSocketListenerConfig[];
+};
+
+export const canonicalWebSocketMatcher = (
+  matcher: SerializableWebSocketMatcher
+): string => matcher.kind === "string"
+  ? `string:${matcher.value}`
+  : `regexp:${matcher.source}/${matcher.flags}`;
+
+const defaultBehavior: WebSocketBehaviorSelection = { preset: "default" };
+
+export const createWebSocketEndpointId = (matcher: SerializableWebSocketMatcher) =>
+  `websocket:endpoint:${canonicalWebSocketMatcher(matcher)}`;
+
+export const createWebSocketListenerId = (endpointId: string, index: number) =>
+  `${endpointId}:message:${index}`;
+
+export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
+  let state: WebSocketStoreState = { endpoints: [], listeners: [] };
+  let endpointOrder = 0;
+
+  const getEndpoint = (id: string) => state.endpoints.find((entry) => entry.endpointId === id);
+  const getListener = (id: string) => state.listeners.find((entry) => entry.info.id === id);
+  const set = (next: WebSocketStoreState) => { state = next; };
+  const registerListener = (listener: WebSocketListenerConfig) => {
+    if (getListener(listener.info.id)) return;
+    const endpoint = getEndpoint(listener.endpointId);
+    if (!endpoint) return;
+    set({
+      endpoints: state.endpoints.map((entry) => entry.endpointId === endpoint.endpointId
+        ? { ...entry, listeners: [...entry.listeners, listener] }
+        : entry),
+      listeners: [...state.listeners, listener],
+    });
+  };
+
+  return {
+    getState: () => state,
+    registerCodeEndpoint: (input: { info: WebSocketHandlerInfo; matcher: SerializableWebSocketMatcher }) => {
+      if (state.endpoints.some((entry) => entry.endpointId === input.info.id)) return;
+      set({ ...state, endpoints: [...state.endpoints, {
+        info: input.info, endpointId: input.info.id, matcher: input.matcher,
+        enabled: true, listeners: [],
+      }] });
+    },
+    registerCodeListener: (input: { info: WebSocketHandlerInfo; endpointId: string; event: "message" }) => {
+      registerListener({ ...input, enabled: true, behavior: defaultBehavior });
+    },
+    addTempEndpoint: (input: { matcher: SerializableWebSocketMatcher; endpoint: string }) => {
+      const endpointId = `${createWebSocketEndpointId(input.matcher)}:${endpointOrder++}`;
+      const info: WebSocketHandlerInfo = { id: endpointId, kind: "websocket", endpoint: input.endpoint, operation: "endpoint", source: "temp" };
+      const config: WebSocketEndpointConfig = { info, endpointId, matcher: input.matcher, enabled: true, listeners: [] };
+      set({ ...state, endpoints: [...state.endpoints, config] });
+      runtime?.addTempEndpoint?.(config);
+      return endpointId;
+    },
+    addTempListener: (input: { endpointId: string; behavior: WebSocketBehaviorSelection }) => {
+      const endpoint = getEndpoint(input.endpointId);
+      if (!endpoint) throw new Error(`WebSocket endpoint not found: ${input.endpointId}`);
+      const index = endpoint.listeners.length;
+      const id = createWebSocketListenerId(input.endpointId, index);
+      const listener: WebSocketListenerConfig = {
+        info: { id, kind: "websocket", endpoint: endpoint.info.endpoint, operation: "message", source: "temp" },
+        endpointId: input.endpointId, event: "message", enabled: true, behavior: input.behavior,
+      };
+      registerListener(listener);
+      return id;
+    },
+    removeEndpoint: (endpointId: string) => {
+      const endpoint = getEndpoint(endpointId);
+      if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+      if (endpoint.info.source !== "temp") throw new Error(`WebSocket endpoints generated from codebase cannot be deleted (id: ${endpointId})`);
+      runtime?.closeEndpointConnections?.(endpointId);
+      runtime?.removeEndpoint?.(endpointId);
+      const listenerIds = new Set(endpoint.listeners.map((entry) => entry.info.id));
+      set({ endpoints: state.endpoints.filter((entry) => entry.endpointId !== endpointId), listeners: state.listeners.filter((entry) => !listenerIds.has(entry.info.id)) });
+    },
+    removeListener: (listenerId: string) => {
+      const listener = getListener(listenerId);
+      if (!listener) throw new Error(`WebSocket listener not found: ${listenerId}`);
+      if (listener.info.source !== "temp") throw new Error(`WebSocket listeners generated from codebase cannot be deleted (id: ${listenerId})`);
+      set({ endpoints: state.endpoints.map((entry) => ({ ...entry, listeners: entry.listeners.filter((item) => item.info.id !== listenerId) })), listeners: state.listeners.filter((entry) => entry.info.id !== listenerId) });
+    },
+    setEndpointEnabled: (endpointId: string, enabled: boolean) => {
+      if (!getEndpoint(endpointId)) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+      if (!enabled) runtime?.closeEndpointConnections?.(endpointId);
+      set({ ...state, endpoints: state.endpoints.map((entry) => entry.endpointId === endpointId ? { ...entry, enabled } : entry) });
+    },
+    setListenerEnabled: (listenerId: string, enabled: boolean) => {
+      if (!getListener(listenerId)) throw new Error(`WebSocket listener not found: ${listenerId}`);
+      set({ endpoints: state.endpoints.map((endpoint) => ({ ...endpoint, listeners: endpoint.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, enabled } : entry) })), listeners: state.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, enabled } : entry) });
+    },
+    setListenerBehavior: (listenerId: string, behavior: WebSocketBehaviorSelection) => {
+      if (!getListener(listenerId)) throw new Error(`WebSocket listener not found: ${listenerId}`);
+      set({ endpoints: state.endpoints.map((endpoint) => ({ ...endpoint, listeners: endpoint.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, behavior } : entry) })), listeners: state.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, behavior } : entry) });
+    },
+    replace: (next: WebSocketEndpointConfig[]) => {
+      set({ endpoints: next, listeners: next.flatMap((entry) => entry.listeners) });
+    },
+    hydrate: (saved: WebSocketEndpointConfig[]) => {
+      const code = state.endpoints.filter((entry) => entry.info.source === "code");
+      const savedById = new Map(saved.map((entry) => [entry.endpointId, entry]));
+      const mergedCode = code.map((entry) => savedById.get(entry.endpointId) ?? entry);
+      const temp = saved.filter((entry) => entry.info.source === "temp");
+      set({ endpoints: [...mergedCode, ...temp], listeners: [...mergedCode, ...temp].flatMap((entry) => entry.listeners) });
+    },
+    reset: () => {
+      runtime?.resetTempEndpoints?.();
+      state = { endpoints: state.endpoints.filter((entry) => entry.info.source === "code").map((entry) => ({ ...entry, listeners: entry.listeners.filter((listener) => listener.info.source === "code") })), listeners: state.listeners.filter((entry) => entry.info.source === "code") };
+    },
+  };
+};
+
+export const managedEndpointToInfo = (endpoint: ManagedWebSocketEndpoint): WebSocketHandlerInfo => ({ id: endpoint.id, kind: "websocket", endpoint: endpoint.endpoint, operation: "endpoint", source: endpoint.source });
+export const managedListenerToInfo = (listener: ManagedWebSocketListener): WebSocketHandlerInfo => ({ id: listener.id, kind: "websocket", endpoint: listener.endpointId, operation: listener.event, source: listener.source });

--- a/packages/core/src/shared/store/webSocketSlice.ts
+++ b/packages/core/src/shared/store/webSocketSlice.ts
@@ -67,7 +67,10 @@ export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
       registerListener({ ...input, enabled: true, behavior: defaultBehavior });
     },
     addTempEndpoint: (input: { matcher: SerializableWebSocketMatcher; endpoint: string }) => {
-      const endpointId = `${createWebSocketEndpointId(input.matcher)}:${endpointOrder++}`;
+      let endpointId = "";
+      do {
+        endpointId = `${createWebSocketEndpointId(input.matcher)}:${endpointOrder++}`;
+      } while (state.endpoints.some((entry) => entry.endpointId === endpointId));
       const info: WebSocketHandlerInfo = { id: endpointId, kind: "websocket", endpoint: input.endpoint, operation: "endpoint", source: "temp" };
       const config: WebSocketEndpointConfig = { info, endpointId, matcher: input.matcher, enabled: true, listeners: [] };
       set({ ...state, endpoints: [...state.endpoints, config] });
@@ -77,14 +80,18 @@ export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
     addTempListener: (input: { endpointId: string; behavior: WebSocketBehaviorSelection }) => {
       const endpoint = getEndpoint(input.endpointId);
       if (!endpoint) throw new Error(`WebSocket endpoint not found: ${input.endpointId}`);
-      const index = endpoint.listeners.length;
-      const id = createWebSocketListenerId(input.endpointId, index);
+      let index = endpoint.listeners.length;
+      let listenerId = createWebSocketListenerId(input.endpointId, index);
+      while (getListener(listenerId)) {
+        index += 1;
+        listenerId = createWebSocketListenerId(input.endpointId, index);
+      }
       const listener: WebSocketListenerConfig = {
-        info: { id, kind: "websocket", endpoint: endpoint.info.endpoint, operation: "message", source: "temp" },
+        info: { id: listenerId, kind: "websocket", endpoint: endpoint.info.endpoint, operation: "message", source: "temp" },
         endpointId: input.endpointId, event: "message", enabled: true, behavior: input.behavior,
       };
       registerListener(listener);
-      return id;
+      return listenerId;
     },
     removeEndpoint: (endpointId: string) => {
       const endpoint = getEndpoint(endpointId);

--- a/packages/core/src/shared/store/webSocketSlice.ts
+++ b/packages/core/src/shared/store/webSocketSlice.ts
@@ -138,4 +138,4 @@ export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
 };
 
 export const managedEndpointToInfo = (endpoint: ManagedWebSocketEndpoint): WebSocketHandlerInfo => ({ id: endpoint.id, kind: "websocket", endpoint: endpoint.endpoint, operation: "endpoint", source: endpoint.source });
-export const managedListenerToInfo = (listener: ManagedWebSocketListener): WebSocketHandlerInfo => ({ id: listener.id, kind: "websocket", endpoint: listener.endpointId, operation: listener.event, source: listener.source });
+export const managedListenerToInfo = (listener: ManagedWebSocketListener, endpoint?: string): WebSocketHandlerInfo => ({ id: listener.id, kind: "websocket", endpoint: endpoint ?? listener.endpointId, operation: listener.event, source: listener.source });

--- a/packages/core/src/shared/store/webSocketSlice.ts
+++ b/packages/core/src/shared/store/webSocketSlice.ts
@@ -1,5 +1,4 @@
 import type {
-  DevToolHandlerInfo,
   ManagedWebSocketEndpoint,
   ManagedWebSocketListener,
   SerializableWebSocketMatcher,

--- a/packages/core/src/shared/types/core.ts
+++ b/packages/core/src/shared/types/core.ts
@@ -6,6 +6,7 @@ import {
 } from "./http";
 import { HttpHandler } from "./msw";
 import { ValueUnion } from "./utils";
+import type { WebSocketEndpointConfig } from "./websocket";
 
 export const CustomBehavior = {
   DEFAULT: "default",
@@ -65,4 +66,5 @@ export interface StorageData {
 /** Browser storage intentionally excludes the non-serializable MSW handler. */
 export interface PersistedStorageData {
   flattenHandlers: PersistedFlattenHandler[];
+  webSocket?: WebSocketEndpointConfig[];
 }

--- a/packages/core/src/shared/types/websocket.ts
+++ b/packages/core/src/shared/types/websocket.ts
@@ -15,3 +15,46 @@ export type ManagedWebSocketListener = {
 export type ManagedWebSocketRegistration = {
   endpoint: ManagedWebSocketEndpoint;
 };
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type DevToolHandlerInfo = {
+  id: string;
+  kind: "http" | "websocket";
+  endpoint: string;
+  operation: string;
+  source: "code" | "temp";
+};
+
+export type SerializableWebSocketMatcher =
+  | { kind: "string"; value: string }
+  | { kind: "regexp"; source: string; flags: string };
+
+export type WebSocketBehaviorSelection = {
+  preset: string;
+  options?: JsonValue;
+};
+
+export type WebSocketHandlerInfo = Omit<DevToolHandlerInfo, "kind"> & { kind: "websocket" };
+
+export type WebSocketListenerConfig = {
+  info: WebSocketHandlerInfo;
+  endpointId: string;
+  event: "message";
+  enabled: boolean;
+  behavior: WebSocketBehaviorSelection;
+};
+
+export type WebSocketEndpointConfig = {
+  info: WebSocketHandlerInfo;
+  endpointId: string;
+  matcher: SerializableWebSocketMatcher;
+  enabled: boolean;
+  listeners: WebSocketListenerConfig[];
+};

--- a/packages/core/src/shared/types/websocket.ts
+++ b/packages/core/src/shared/types/websocket.ts
@@ -21,14 +21,6 @@ export type ManagedWebSocketRegistration = {
   endpoint: ManagedWebSocketEndpoint;
 };
 
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
-
 export type DevToolHandlerInfo = {
   id: string;
   kind: "http" | "websocket";
@@ -39,7 +31,7 @@ export type DevToolHandlerInfo = {
 
 export type WebSocketBehaviorSelection = {
   preset: string;
-  options?: JsonValue;
+  options?: unknown;
 };
 
 export type WebSocketHandlerInfo = Omit<DevToolHandlerInfo, "kind"> & { kind: "websocket" };

--- a/packages/core/src/shared/types/websocket.ts
+++ b/packages/core/src/shared/types/websocket.ts
@@ -1,7 +1,12 @@
+export type SerializableWebSocketMatcher =
+  | { kind: "string"; value: string }
+  | { kind: "regexp"; source: string; flags: string };
+
 export type ManagedWebSocketEndpoint = {
   id: string;
   endpoint: string;
   source: "code";
+  matcher?: SerializableWebSocketMatcher;
 };
 
 export type ManagedWebSocketListener = {
@@ -31,10 +36,6 @@ export type DevToolHandlerInfo = {
   operation: string;
   source: "code" | "temp";
 };
-
-export type SerializableWebSocketMatcher =
-  | { kind: "string"; value: string }
-  | { kind: "regexp"; source: string; flags: string };
 
 export type WebSocketBehaviorSelection = {
   preset: string;


### PR DESCRIPTION
## Abstract

This PR adds a unified state model for WebSocket endpoints and message listeners alongside the existing HTTP handler store.

It separates common handler metadata from WebSocket-specific state and connects code/temp lifecycle, enabled state, listener behavior, Browser `sessionStorage`, and Node session snapshots through one persistence flow.

## Issues

<!-- No issue number was provided for this implementation PR. -->

## Description

### Implementation

The implementation defines the state and lifecycle boundary only. The WebSocket dispatcher, `send`/`close` execution, UI, and Browser/Node CLI commands remain out of scope.

```mermaid
flowchart LR
    Discovery[Code handler discovery] --> Store[Unified HandlerStore]
    Temp[Temporary endpoint/listener API] --> Store
    Store --> Registry[Common handler registry]
    Store --> Slice[WebSocket state slice]
    Slice --> Runtime[WebSocket runtime adapter]
    Store --> Persistence[Persistence coordinator]
    Persistence --> Browser[Browser sessionStorage]
    Persistence --> Node[Node session snapshot]
```

The declarative state boundaries are:

- `common`: registration, lookup, and cleanup for HTTP/WebSocket metadata
- `webSocket`: endpoint/listener hierarchy, matcher, enabled state, and behavior
- runtime adapter: temporary endpoint lifecycle and connection cleanup requests
- persistence: only serializable state crosses the Browser/Node boundary

### Handler Structure

The handler structure keeps protocol-independent metadata separate from the WebSocket-specific hierarchy. The existing HTTP flat state remains for compatibility and is also registered in the common registry.

```mermaid
flowchart TD
    HandlerStore[HandlerStore]
    HandlerStore --> Common[Common registry]
    HandlerStore --> HTTP[HTTP state\nlegacy-compatible flattenHandlers]
    HandlerStore --> WS[WebSocket slice]

    Common --> HTTPMeta[HTTP metadata\nkind / endpoint / operation / source]
    Common --> WSMeta[WebSocket metadata\nkind / endpoint / operation / source]

    WS --> Endpoint[WebSocket endpoint]
    Endpoint --> Matcher[String or RegExp matcher]
    Endpoint --> EndpointState[enabled]
    Endpoint --> Listener[Message listener]
    Listener --> ListenerState[enabled + behavior]
```

Lifecycle semantics:

- code endpoints/listeners are registered during discovery and cannot be deleted.
- deleting a temporary endpoint also removes its listeners and requests runtime connection cleanup.
- reset preserves the code baseline and removes temporary state.
- matchers preserve strings and RegExp values as `{ source, flags }`.
- endpoint/listener IDs remain unique after persistence hydration and deletion.

## Additional Context
