### PR TITLE
feat(cli-core): add WebSocket commands and session interface

### DIFF
--- a/packages/browser-cli/src/session.test.ts
+++ b/packages/browser-cli/src/session.test.ts
@@ -113,4 +113,17 @@ describe("CdpBrowserCliSession", () => {
     const client = { call: vi.fn().mockResolvedValue({ exceptionDetails: { text: "" } }) } as unknown as CdpClient;
     await expect(new CdpBrowserCliSession(client).describe()).rejects.toThrow("CDP evaluation failed");
   });
+
+  it("rejects all WebSocket stub methods as not implemented", async () => {
+    const session = new CdpBrowserCliSession({ call: vi.fn() } as unknown as CdpClient);
+    await expect(session.listWebSocket()).rejects.toThrow("not implemented");
+    await expect(session.getWebSocketEndpoint("id")).rejects.toThrow("not implemented");
+    await expect(session.addWebSocketEndpoint({ kind: "string", value: "ws://localhost" })).rejects.toThrow("not implemented");
+    await expect(session.removeWebSocketEndpoint("id")).rejects.toThrow("not implemented");
+    await expect(session.setWebSocketEndpointEnabled("id", true)).rejects.toThrow("not implemented");
+    await expect(session.addWebSocketListener("id", { preset: "send" })).rejects.toThrow("not implemented");
+    await expect(session.removeWebSocketListener("id")).rejects.toThrow("not implemented");
+    await expect(session.setWebSocketListenerEnabled("id", true)).rejects.toThrow("not implemented");
+    await expect(session.setWebSocketListenerBehavior("id", { preset: "close" })).rejects.toThrow("not implemented");
+  });
 });

--- a/packages/browser-cli/src/session.ts
+++ b/packages/browser-cli/src/session.ts
@@ -45,4 +45,13 @@ export class CdpBrowserCliSession implements CliSession {
   public addTemp(data: TempHandlerInput): Promise<CliMutationResult> { return this.invoke("addTemp", [data]); }
   public removeTemp(id: string): Promise<CliSessionInfo> { return this.invoke("removeTemp", [id]); }
   public reset(): Promise<CliSessionInfo> { return this.invoke("reset"); }
+  public async listWebSocket(): Promise<never[]> { throw new Error("not implemented"); }
+  public async getWebSocketEndpoint(): Promise<undefined> { throw new Error("not implemented"); }
+  public async addWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
+  public async removeWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
+  public async setWebSocketEndpointEnabled(): Promise<never> { throw new Error("not implemented"); }
+  public async addWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
+  public async removeWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
+  public async setWebSocketListenerEnabled(): Promise<never> { throw new Error("not implemented"); }
+  public async setWebSocketListenerBehavior(): Promise<never> { throw new Error("not implemented"); }
 }

--- a/packages/cli-core/src/commands.ts
+++ b/packages/cli-core/src/commands.ts
@@ -2,6 +2,8 @@ import {
   customResponseSchema,
   HttpHandlerBehavior,
   tempHandlerSchema,
+  webSocketBehaviorSchema,
+  serializableWebSocketMatcherSchema,
 } from "@msw-dev-tool/core/shared";
 import type { CliCommand, CliCommandContext, JsonResult } from "./types";
 
@@ -109,6 +111,97 @@ export const commands: CliCommand[] = [
     usage: "reset",
     async execute(context) {
       return withMetadata({ ok: true, ...(await context.session.reset()) }, context);
+    },
+  },
+  {
+    name: "ws-list",
+    usage: "ws-list",
+    async execute(context) {
+      return withMetadata({ ok: true, endpoints: await context.session.listWebSocket() }, context);
+    },
+  },
+  {
+    name: "ws-get-endpoint",
+    usage: "ws-get-endpoint <endpointId>",
+    async execute(context, { positionals }) {
+      const id = positionals[1];
+      if (!id) throw new Error("Usage: ws-get-endpoint <endpointId>");
+      const endpoint = await context.session.getWebSocketEndpoint(id);
+      if (!endpoint) throw new Error(`WebSocket endpoint not found for id: ${id}`);
+      return withMetadata({ ok: true, endpoint }, context);
+    },
+  },
+  {
+    name: "ws-add-endpoint",
+    usage: "ws-add-endpoint --json '<matcherJson>'",
+    async execute(context, { flags }) {
+      if (typeof flags.json !== "string") {
+        throw new Error("Usage: ws-add-endpoint --json '<matcherJson>'");
+      }
+      const matcher = serializableWebSocketMatcherSchema.parse(JSON.parse(flags.json) as unknown);
+      return withMetadata({ ok: true, ...(await context.session.addWebSocketEndpoint(matcher)) }, context);
+    },
+  },
+  {
+    name: "ws-remove-endpoint",
+    usage: "ws-remove-endpoint <endpointId>",
+    async execute(context, { positionals }) {
+      const id = positionals[1];
+      if (!id) throw new Error("Usage: ws-remove-endpoint <endpointId>");
+      return withMetadata({ ok: true, ...(await context.session.removeWebSocketEndpoint(id)) }, context);
+    },
+  },
+  {
+    name: "ws-set-endpoint-enabled",
+    usage: "ws-set-endpoint-enabled <endpointId> <true|false>",
+    async execute(context, { positionals }) {
+      const [id, enabledStr] = [positionals[1], positionals[2]];
+      if (!id || enabledStr === undefined) throw new Error("Usage: ws-set-endpoint-enabled <endpointId> <true|false>");
+      if (enabledStr !== "true" && enabledStr !== "false") throw new Error("enabled must be true or false");
+      return withMetadata({ ok: true, ...(await context.session.setWebSocketEndpointEnabled(id, enabledStr === "true")) }, context);
+    },
+  },
+  {
+    name: "ws-add-listener",
+    usage: "ws-add-listener <endpointId> --json '<behaviorJson>'",
+    async execute(context, { flags, positionals }) {
+      const id = positionals[1];
+      if (!id || typeof flags.json !== "string") {
+        throw new Error("Usage: ws-add-listener <endpointId> --json '<behaviorJson>'");
+      }
+      const behavior = webSocketBehaviorSchema.parse(JSON.parse(flags.json) as unknown);
+      return withMetadata({ ok: true, ...(await context.session.addWebSocketListener(id, behavior)) }, context);
+    },
+  },
+  {
+    name: "ws-remove-listener",
+    usage: "ws-remove-listener <listenerId>",
+    async execute(context, { positionals }) {
+      const id = positionals[1];
+      if (!id) throw new Error("Usage: ws-remove-listener <listenerId>");
+      return withMetadata({ ok: true, ...(await context.session.removeWebSocketListener(id)) }, context);
+    },
+  },
+  {
+    name: "ws-set-listener-enabled",
+    usage: "ws-set-listener-enabled <listenerId> <true|false>",
+    async execute(context, { positionals }) {
+      const [id, enabledStr] = [positionals[1], positionals[2]];
+      if (!id || enabledStr === undefined) throw new Error("Usage: ws-set-listener-enabled <listenerId> <true|false>");
+      if (enabledStr !== "true" && enabledStr !== "false") throw new Error("enabled must be true or false");
+      return withMetadata({ ok: true, ...(await context.session.setWebSocketListenerEnabled(id, enabledStr === "true")) }, context);
+    },
+  },
+  {
+    name: "ws-set-listener-behavior",
+    usage: "ws-set-listener-behavior <listenerId> --json '<behaviorJson>'",
+    async execute(context, { flags, positionals }) {
+      const id = positionals[1];
+      if (!id || typeof flags.json !== "string") {
+        throw new Error("Usage: ws-set-listener-behavior <listenerId> --json '<behaviorJson>'");
+      }
+      const behavior = webSocketBehaviorSchema.parse(JSON.parse(flags.json) as unknown);
+      return withMetadata({ ok: true, ...(await context.session.setWebSocketListenerBehavior(id, behavior)) }, context);
     },
   },
 ];

--- a/packages/cli-core/src/index.test.ts
+++ b/packages/cli-core/src/index.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
+import type { WebSocketEndpointConfig, WebSocketListenerConfig } from "@msw-dev-tool/core/shared";
 import { CliHandler, CliSession, commandUsage, commands, findCommand, parseArgs, printJson } from "./index";
 
 const handler: CliHandler = { id: "a", path: "/a", method: "get", behavior: "default", type: "default" };
+
+const wsEndpoint: WebSocketEndpointConfig = {
+  info: { id: "ws:ep:1", kind: "websocket", endpoint: "ws://localhost/chat", operation: "endpoint", source: "temp" },
+  endpointId: "ws:ep:1",
+  matcher: { kind: "string", value: "ws://localhost/chat" },
+  enabled: true,
+  listeners: [],
+};
+
+const wsListener: WebSocketListenerConfig = {
+  info: { id: "ws:ep:1:message:0", kind: "websocket", endpoint: "ws://localhost/chat", operation: "message", source: "temp" },
+  endpointId: "ws:ep:1",
+  event: "message",
+  enabled: true,
+  behavior: { preset: "send", options: { message: "hello" } },
+};
+
+const wsEndpointWithListener: WebSocketEndpointConfig = { ...wsEndpoint, listeners: [wsListener] };
+
 const createSession = (): CliSession => {
   const handlers = [{ ...handler }];
   let revision = 0;
@@ -11,6 +31,15 @@ const createSession = (): CliSession => {
     setBehavior: async (id, behavior) => { const item = handlers.find((entry) => entry.id === id); if (!item) throw new Error(`Handler not found for id: ${id}`); item.behavior = behavior; revision += 1; return { ...info(), handler: item }; },
     setCustomResponse: async (id, customResponse) => { const item = handlers.find((entry) => entry.id === id); if (!item) throw new Error(`Handler not found for id: ${id}`); item.customResponse = customResponse; revision += 1; return { ...info(), handler: item }; },
     addTemp: async () => { throw new Error("not used"); }, removeTemp: async () => { throw new Error("not used"); }, reset: async () => info(),
+    listWebSocket: async () => [wsEndpoint],
+    getWebSocketEndpoint: async (id) => id === wsEndpoint.endpointId ? wsEndpoint : undefined,
+    addWebSocketEndpoint: async () => ({ endpoint: wsEndpoint }),
+    removeWebSocketEndpoint: async () => ({ endpoints: [] }),
+    setWebSocketEndpointEnabled: async () => ({ endpoint: wsEndpoint }),
+    addWebSocketListener: async () => ({ endpoint: wsEndpointWithListener, listener: wsListener }),
+    removeWebSocketListener: async () => ({ endpoints: [wsEndpoint] }),
+    setWebSocketListenerEnabled: async () => ({ endpoint: wsEndpointWithListener, listener: wsListener }),
+    setWebSocketListenerBehavior: async () => ({ endpoint: wsEndpointWithListener, listener: wsListener }),
   };
 };
 
@@ -75,6 +104,70 @@ describe("shared CLI commands", () => {
     await expect(findCommand("add-temp")!.execute(context, { flags: { json: '{"path":"/tmp","method":"get","contentType":"text/plain","status":"200","response":"ok"}' }, positionals: ["add-temp"] })).resolves.toMatchObject({ revision: 4 });
     await expect(findCommand("remove-temp")!.execute(context, { flags: {}, positionals: ["remove-temp", "a"] })).resolves.toMatchObject({ revision: 5 });
     await expect(findCommand("reset")!.execute(context, { flags: {}, positionals: ["reset"] })).resolves.toMatchObject({ revision: 6 });
+  });
+
+  it("executes ws-list and ws-get-endpoint", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-list")!.execute(context, { flags: {}, positionals: ["ws-list"] })).resolves.toMatchObject({ ok: true, endpoints: [wsEndpoint] });
+    await expect(findCommand("ws-get-endpoint")!.execute(context, { flags: {}, positionals: ["ws-get-endpoint", wsEndpoint.endpointId] })).resolves.toMatchObject({ ok: true, endpoint: wsEndpoint });
+  });
+
+  it("executes ws-add-endpoint and ws-remove-endpoint", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-add-endpoint")!.execute(context, { flags: { json: '{"kind":"string","value":"ws://localhost/chat"}' }, positionals: ["ws-add-endpoint"] })).resolves.toMatchObject({ ok: true, endpoint: wsEndpoint });
+    await expect(findCommand("ws-remove-endpoint")!.execute(context, { flags: {}, positionals: ["ws-remove-endpoint", wsEndpoint.endpointId] })).resolves.toMatchObject({ ok: true, endpoints: [] });
+  });
+
+  it("executes ws-set-endpoint-enabled", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-set-endpoint-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-endpoint-enabled", wsEndpoint.endpointId, "false"] })).resolves.toMatchObject({ ok: true, endpoint: wsEndpoint });
+    await expect(findCommand("ws-set-endpoint-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-endpoint-enabled", wsEndpoint.endpointId, "true"] })).resolves.toMatchObject({ ok: true });
+  });
+
+  it("executes ws-add-listener and ws-remove-listener", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-add-listener")!.execute(context, { flags: { json: '{"preset":"send","options":{"message":"hello"}}' }, positionals: ["ws-add-listener", wsEndpoint.endpointId] })).resolves.toMatchObject({ ok: true, listener: wsListener });
+    await expect(findCommand("ws-remove-listener")!.execute(context, { flags: {}, positionals: ["ws-remove-listener", wsListener.info.id] })).resolves.toMatchObject({ ok: true, endpoints: [wsEndpoint] });
+  });
+
+  it("executes ws-set-listener-enabled and ws-set-listener-behavior", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-set-listener-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-listener-enabled", wsListener.info.id, "false"] })).resolves.toMatchObject({ ok: true, listener: wsListener });
+    await expect(findCommand("ws-set-listener-behavior")!.execute(context, { flags: { json: '{"preset":"close"}' }, positionals: ["ws-set-listener-behavior", wsListener.info.id] })).resolves.toMatchObject({ ok: true, listener: wsListener });
+  });
+
+  it("rejects ws commands with missing arguments", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-get-endpoint")!.execute(context, { flags: {}, positionals: ["ws-get-endpoint"] })).rejects.toThrow("Usage: ws-get-endpoint");
+    await expect(findCommand("ws-add-endpoint")!.execute(context, { flags: {}, positionals: ["ws-add-endpoint"] })).rejects.toThrow("Usage: ws-add-endpoint");
+    await expect(findCommand("ws-remove-endpoint")!.execute(context, { flags: {}, positionals: ["ws-remove-endpoint"] })).rejects.toThrow("Usage: ws-remove-endpoint");
+    await expect(findCommand("ws-set-endpoint-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-endpoint-enabled", wsEndpoint.endpointId] })).rejects.toThrow("Usage: ws-set-endpoint-enabled");
+    await expect(findCommand("ws-set-endpoint-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-endpoint-enabled", wsEndpoint.endpointId, "maybe"] })).rejects.toThrow("enabled must be true or false");
+    await expect(findCommand("ws-add-listener")!.execute(context, { flags: {}, positionals: ["ws-add-listener", wsEndpoint.endpointId] })).rejects.toThrow("Usage: ws-add-listener");
+    await expect(findCommand("ws-remove-listener")!.execute(context, { flags: {}, positionals: ["ws-remove-listener"] })).rejects.toThrow("Usage: ws-remove-listener");
+    await expect(findCommand("ws-set-listener-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-listener-enabled", wsListener.info.id] })).rejects.toThrow("Usage: ws-set-listener-enabled");
+    await expect(findCommand("ws-set-listener-enabled")!.execute(context, { flags: {}, positionals: ["ws-set-listener-enabled", wsListener.info.id, "maybe"] })).rejects.toThrow("enabled must be true or false");
+    await expect(findCommand("ws-set-listener-behavior")!.execute(context, { flags: {}, positionals: ["ws-set-listener-behavior", wsListener.info.id] })).rejects.toThrow("Usage: ws-set-listener-behavior");
+  });
+
+  it("rejects ws-get-endpoint when endpoint is not found", async () => {
+    const session = createSession();
+    session.getWebSocketEndpoint = vi.fn().mockResolvedValue(undefined);
+    await expect(findCommand("ws-get-endpoint")!.execute({ session }, { flags: {}, positionals: ["ws-get-endpoint", "nonexistent"] })).rejects.toThrow("WebSocket endpoint not found");
+  });
+
+  it("rejects ws commands with invalid JSON", async () => {
+    const session = createSession();
+    const context = { session };
+    await expect(findCommand("ws-add-endpoint")!.execute(context, { flags: { json: "{bad}" }, positionals: ["ws-add-endpoint"] })).rejects.toThrow();
+    await expect(findCommand("ws-add-listener")!.execute(context, { flags: { json: "{bad}" }, positionals: ["ws-add-listener", wsEndpoint.endpointId] })).rejects.toThrow();
+    await expect(findCommand("ws-set-listener-behavior")!.execute(context, { flags: { json: "{bad}" }, positionals: ["ws-set-listener-behavior", wsListener.info.id] })).rejects.toThrow();
   });
 
   it("reports missing handlers and invalid command inputs", async () => {

--- a/packages/cli-core/src/types.ts
+++ b/packages/cli-core/src/types.ts
@@ -3,6 +3,10 @@ import type {
   HttpHandlerBehavior,
   PersistedFlattenHandler,
   TempHandlerInput,
+  WebSocketEndpointConfig,
+  WebSocketListenerConfig,
+  WebSocketBehaviorSelection,
+  SerializableWebSocketMatcher,
 } from "@msw-dev-tool/core/shared";
 
 export type CliHandler = PersistedFlattenHandler;
@@ -15,6 +19,19 @@ export type CliSessionInfo = {
 
 export type CliMutationResult = CliSessionInfo & { handler: CliHandler };
 
+export type CliWebSocketInfo = {
+  endpoints: WebSocketEndpointConfig[];
+};
+
+export type CliWebSocketEndpointResult = {
+  endpoint: WebSocketEndpointConfig;
+};
+
+export type CliWebSocketListenerResult = {
+  endpoint: WebSocketEndpointConfig;
+  listener: WebSocketListenerConfig;
+};
+
 export type CliSession = {
   describe(): Promise<CliSessionInfo>;
   list(): Promise<CliHandler[]>;
@@ -24,6 +41,15 @@ export type CliSession = {
   addTemp(data: TempHandlerInput): Promise<CliMutationResult>;
   removeTemp(id: string): Promise<CliSessionInfo>;
   reset(): Promise<CliSessionInfo>;
+  listWebSocket(): Promise<WebSocketEndpointConfig[]>;
+  getWebSocketEndpoint(endpointId: string): Promise<WebSocketEndpointConfig | undefined>;
+  addWebSocketEndpoint(matcher: SerializableWebSocketMatcher): Promise<CliWebSocketEndpointResult>;
+  removeWebSocketEndpoint(endpointId: string): Promise<CliWebSocketInfo>;
+  setWebSocketEndpointEnabled(endpointId: string, enabled: boolean): Promise<CliWebSocketEndpointResult>;
+  addWebSocketListener(endpointId: string, behavior: WebSocketBehaviorSelection): Promise<CliWebSocketListenerResult>;
+  removeWebSocketListener(listenerId: string): Promise<CliWebSocketInfo>;
+  setWebSocketListenerEnabled(listenerId: string, enabled: boolean): Promise<CliWebSocketListenerResult>;
+  setWebSocketListenerBehavior(listenerId: string, behavior: WebSocketBehaviorSelection): Promise<CliWebSocketListenerResult>;
 };
 
 export type ParsedArgs = {

--- a/packages/core/src/shared/schema/index.ts
+++ b/packages/core/src/shared/schema/index.ts
@@ -26,4 +26,4 @@ export {
   isValidHandlerPath,
 } from "./handler";
 export type { TempHandlerSchema, HandlerSchema, CustomResponseSchema } from "./handler";
-export { webSocketEndpointsSchema, webSocketEndpointSchema, webSocketListenerSchema, serializableWebSocketMatcherSchema } from "./websocket";
+export { webSocketEndpointsSchema, webSocketEndpointSchema, webSocketListenerSchema, serializableWebSocketMatcherSchema, webSocketBehaviorSchema, webSocketSendOptionsSchema, webSocketCloseOptionsSchema } from "./websocket";

--- a/packages/node-cli/src/cli/session.test.ts
+++ b/packages/node-cli/src/cli/session.test.ts
@@ -30,6 +30,19 @@ describe("FileSnapshotCliSession", () => {
     vi.useRealTimers();
   });
 
+  it("rejects all WebSocket stub methods as not implemented", async () => {
+    const session = new FileSnapshotCliSession("/tmp/session.json");
+    await expect(session.listWebSocket()).rejects.toThrow("not implemented");
+    await expect(session.getWebSocketEndpoint("id")).rejects.toThrow("not implemented");
+    await expect(session.addWebSocketEndpoint({ kind: "string", value: "ws://localhost" })).rejects.toThrow("not implemented");
+    await expect(session.removeWebSocketEndpoint("id")).rejects.toThrow("not implemented");
+    await expect(session.setWebSocketEndpointEnabled("id", true)).rejects.toThrow("not implemented");
+    await expect(session.addWebSocketListener("id", { preset: "send" })).rejects.toThrow("not implemented");
+    await expect(session.removeWebSocketListener("id")).rejects.toThrow("not implemented");
+    await expect(session.setWebSocketListenerEnabled("id", true)).rejects.toThrow("not implemented");
+    await expect(session.setWebSocketListenerBehavior("id", { preset: "close" })).rejects.toThrow("not implemented");
+  });
+
   it("reports mutations that cannot find the resulting handler", async () => {
     vi.useFakeTimers();
     api.setSnapshotBehavior.mockReturnValue(snapshot([]));

--- a/packages/node-cli/src/cli/session.ts
+++ b/packages/node-cli/src/cli/session.ts
@@ -55,4 +55,13 @@ export class FileSnapshotCliSession implements CliSession {
     await settleAfterWrite();
     return toInfo(await readSessionSnapshot(this.sessionPath));
   }
+  public async listWebSocket(): Promise<never[]> { throw new Error("not implemented"); }
+  public async getWebSocketEndpoint(): Promise<undefined> { throw new Error("not implemented"); }
+  public async addWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
+  public async removeWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
+  public async setWebSocketEndpointEnabled(): Promise<never> { throw new Error("not implemented"); }
+  public async addWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
+  public async removeWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
+  public async setWebSocketListenerEnabled(): Promise<never> { throw new Error("not implemented"); }
+  public async setWebSocketListenerBehavior(): Promise<never> { throw new Error("not implemented"); }
 }


### PR DESCRIPTION
## Abstract

Add WebSocket support to `cli-core` by introducing new types, `CliSession` methods, and nine `ws-*` CLI commands. This forms the contract layer that `browser-cli` and `node-cli` will implement in subsequent PRs.

## Issues

<!-- No linked issue -->

## Description

### Changes



## Additional Context

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to list, inspect, create, remove, enable, and configure WebSocket endpoints.
  * Added support for managing WebSocket listeners, including enabling, removing, and updating their behavior.
  * Added validation for required arguments, identifiers, boolean values, and JSON configuration.
  * Exposed additional WebSocket configuration schemas for broader integration support.

* **Tests**
  * Added coverage for WebSocket endpoint and listener operations, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->