### PR TITLE
feat(node-cli): implement WebSocket file session

### DIFF
--- a/.changeset/node-cli-websocket-session.md
+++ b/.changeset/node-cli-websocket-session.md
@@ -1,0 +1,5 @@
+---
+"@msw-dev-tool/node-cli": minor
+---
+
+Add WebSocket endpoint and listener management through Node CLI snapshot sessions.

--- a/packages/core/src/node/snapshot/file.ts
+++ b/packages/core/src/node/snapshot/file.ts
@@ -5,7 +5,8 @@ import { createEmptySnapshot } from "./serialize";
 import { sessionSnapshotSchema, SessionSnapshot } from "./types";
 
 const LOCK_STALE_MS = 15_000;
-const LOCK_MAX_ATTEMPTS = 10;
+// TODO: Add a per-path in-memory queue if same-process mutation contention becomes common.
+const LOCK_MAX_ATTEMPTS = 30;
 const LOCK_BACKOFF_MS = { min: 50, max: 500, factor: 1.5 } as const;
 
 const pathExists = async (filePath: string): Promise<boolean> => {

--- a/packages/core/src/node/snapshot/mutations.ts
+++ b/packages/core/src/node/snapshot/mutations.ts
@@ -1,5 +1,21 @@
 import { getRowId } from "../../shared/utils/store";
-import { CustomResponse, HttpHandlerBehavior, TempHandlerInput } from "../../shared/types";
+import {
+  CustomResponse,
+  HttpHandlerBehavior,
+  SerializableWebSocketMatcher,
+  TempHandlerInput,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
+} from "../../shared/types";
+import {
+  webSocketEndpointSchema,
+  webSocketBehaviorSchema,
+  webSocketListenerSchema,
+} from "../../shared/schema/websocket";
+import {
+  createWebSocketEndpointId,
+  createWebSocketListenerId,
+} from "../../shared/store/webSocketSlice";
 import { bumpSnapshot } from "./serialize";
 import { readSnapshotOrEmpty, withLockedMutation } from "./file";
 import { SessionSnapshot, SerializableFlattenHandler } from "./types";
@@ -12,6 +28,166 @@ export const getSnapshotHandler = async (
   id: string
 ): Promise<SerializableFlattenHandler | undefined> =>
   (await listSnapshotHandlers(sessionPath)).find((handler) => handler.id === id);
+
+type SnapshotWebSocketEndpoint = NonNullable<SessionSnapshot["state"]["webSocket"]>[number];
+
+const snapshotWebSocketEndpoints = (snapshot: SessionSnapshot): SnapshotWebSocketEndpoint[] =>
+  snapshot.state.webSocket ?? [];
+
+const endpointFromMatcher = (matcher: SerializableWebSocketMatcher): string =>
+  matcher.kind === "string" ? matcher.value : `/${matcher.source}/${matcher.flags}`;
+
+export const listSnapshotWebSocketEndpoints = async (
+  sessionPath: string
+): Promise<WebSocketEndpointConfig[]> => snapshotWebSocketEndpoints(await readSnapshotOrEmpty(sessionPath));
+
+export const getSnapshotWebSocketEndpoint = async (
+  sessionPath: string,
+  endpointId: string
+): Promise<WebSocketEndpointConfig | undefined> =>
+  (await listSnapshotWebSocketEndpoints(sessionPath)).find((endpoint) => endpoint.endpointId === endpointId);
+
+export const addSnapshotWebSocketEndpoint = (
+  sessionPath: string,
+  matcher: SerializableWebSocketMatcher
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  let index = 0;
+  let endpointId = `${createWebSocketEndpointId(matcher)}:${index}`;
+  while (endpoints.some((endpoint) => endpoint.endpointId === endpointId)) {
+    index += 1;
+    endpointId = `${createWebSocketEndpointId(matcher)}:${index}`;
+  }
+  const endpoint = webSocketEndpointSchema.parse({
+    info: {
+      id: endpointId,
+      kind: "websocket",
+      endpoint: endpointFromMatcher(matcher),
+      operation: "endpoint",
+      source: "temp",
+    },
+    endpointId,
+    matcher,
+    enabled: true,
+    listeners: [],
+  });
+  return bumpSnapshot(prev, { webSocket: [...endpoints, endpoint] });
+});
+
+export const removeSnapshotWebSocketEndpoint = (
+  sessionPath: string,
+  endpointId: string
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  const endpoint = endpoints.find((entry) => entry.endpointId === endpointId);
+  if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+  if (endpoint.info.source !== "temp") {
+    throw new Error(`WebSocket endpoints generated from codebase cannot be deleted (id: ${endpointId})`);
+  }
+  return bumpSnapshot(prev, { webSocket: endpoints.filter((entry) => entry.endpointId !== endpointId) });
+});
+
+export const setSnapshotWebSocketEndpointEnabled = (
+  sessionPath: string,
+  endpointId: string,
+  enabled: boolean
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  if (!endpoints.some((endpoint) => endpoint.endpointId === endpointId)) {
+    throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+  }
+  return bumpSnapshot(prev, {
+    webSocket: endpoints.map((endpoint) => endpoint.endpointId === endpointId ? { ...endpoint, enabled } : endpoint),
+  });
+});
+
+export const addSnapshotWebSocketListener = (
+  sessionPath: string,
+  endpointId: string,
+  behavior: WebSocketBehaviorSelection
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  const endpoint = endpoints.find((entry) => entry.endpointId === endpointId);
+  if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+  let index = endpoint.listeners.length;
+  let listenerId = createWebSocketListenerId(endpointId, index);
+  const listeners = endpoints.flatMap((entry) => entry.listeners);
+  while (listeners.some((listener) => listener.info.id === listenerId)) {
+    index += 1;
+    listenerId = createWebSocketListenerId(endpointId, index);
+  }
+  const listener = webSocketListenerSchema.parse({
+    info: {
+      id: listenerId,
+      kind: "websocket" as const,
+      endpoint: endpoint.info.endpoint,
+      operation: "message",
+      source: "temp" as const,
+    },
+    endpointId,
+    event: "message" as const,
+    enabled: true,
+    behavior,
+  });
+  return bumpSnapshot(prev, {
+    webSocket: endpoints.map((entry) => entry.endpointId === endpointId
+      ? { ...entry, listeners: [...entry.listeners, listener] }
+      : entry),
+  });
+});
+
+export const removeSnapshotWebSocketListener = (
+  sessionPath: string,
+  listenerId: string
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  const listener = endpoints.flatMap((endpoint) => endpoint.listeners).find((entry) => entry.info.id === listenerId);
+  if (!listener) throw new Error(`WebSocket listener not found: ${listenerId}`);
+  if (listener.info.source !== "temp") {
+    throw new Error(`WebSocket listeners generated from codebase cannot be deleted (id: ${listenerId})`);
+  }
+  return bumpSnapshot(prev, {
+    webSocket: endpoints.map((endpoint) => ({
+      ...endpoint,
+      listeners: endpoint.listeners.filter((entry) => entry.info.id !== listenerId),
+    })),
+  });
+});
+
+export const setSnapshotWebSocketListenerEnabled = (
+  sessionPath: string,
+  listenerId: string,
+  enabled: boolean
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  if (!endpoints.some((endpoint) => endpoint.listeners.some((listener) => listener.info.id === listenerId))) {
+    throw new Error(`WebSocket listener not found: ${listenerId}`);
+  }
+  return bumpSnapshot(prev, {
+    webSocket: endpoints.map((endpoint) => ({
+      ...endpoint,
+      listeners: endpoint.listeners.map((listener) => listener.info.id === listenerId ? { ...listener, enabled } : listener),
+    })),
+  });
+});
+
+export const setSnapshotWebSocketListenerBehavior = (
+  sessionPath: string,
+  listenerId: string,
+  behavior: WebSocketBehaviorSelection
+): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
+  const endpoints = snapshotWebSocketEndpoints(prev);
+  if (!endpoints.some((endpoint) => endpoint.listeners.some((listener) => listener.info.id === listenerId))) {
+    throw new Error(`WebSocket listener not found: ${listenerId}`);
+  }
+  const nextBehavior = webSocketBehaviorSchema.parse(behavior);
+  return bumpSnapshot(prev, {
+    webSocket: endpoints.map((endpoint) => ({
+      ...endpoint,
+      listeners: endpoint.listeners.map((listener) => listener.info.id === listenerId ? { ...listener, behavior: nextBehavior } : listener),
+    })),
+  });
+});
 
 export const setSnapshotBehavior = (
   sessionPath: string, id: string, behavior: HttpHandlerBehavior
@@ -47,6 +223,3 @@ export const removeSnapshotTempHandler = (
 
 export const requestSnapshotReset = (sessionPath: string): Promise<SessionSnapshot> =>
   withLockedMutation(sessionPath, (prev) => bumpSnapshot(prev, { flattenHandlers: prev.state.flattenHandlers, pendingReset: true }));
-
-export const readSessionSnapshot = (sessionPath: string): Promise<SessionSnapshot> =>
-  readSnapshotOrEmpty(sessionPath);

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -15,7 +15,16 @@ import {
   removeSnapshotTempHandler,
   requestSnapshotReset,
   getSnapshotHandler,
+  getSnapshotWebSocketEndpoint,
   listSnapshotHandlers,
+  listSnapshotWebSocketEndpoints,
+  addSnapshotWebSocketEndpoint,
+  addSnapshotWebSocketListener,
+  removeSnapshotWebSocketEndpoint,
+  removeSnapshotWebSocketListener,
+  setSnapshotWebSocketEndpointEnabled,
+  setSnapshotWebSocketListenerBehavior,
+  setSnapshotWebSocketListenerEnabled,
   readSnapshotOrEmpty,
   getSessionPathForPid,
   listSessionPids,
@@ -29,6 +38,7 @@ import {
 } from "../../shared/types";
 import { FlattenHandler } from "../../shared/types";
 import { getRowId } from "../../shared/utils/store";
+import { webSocketEndpointSchema } from "../../shared/schema/websocket";
 
 const require = createRequire(import.meta.url);
 const tempDirs: string[] = [];
@@ -123,6 +133,140 @@ describe("snapshot file protocol", () => {
     expect(next.state.flattenHandlers).toHaveLength(1);
     expect(next.state.flattenHandlers[0]?.type).toBe("temp");
     expect(next.state.flattenHandlers[0]?.tempInput?.path).toBe("/api/tmp");
+  });
+
+  it("reads and mutates WebSocket endpoints in a snapshot", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await fs.promises.writeFile(sessionPath, JSON.stringify({
+      revision: 0,
+      owner: { pid: process.pid },
+      state: { flattenHandlers: [] },
+    }));
+
+    await expect(listSnapshotWebSocketEndpoints(sessionPath)).resolves.toEqual([]);
+    const added = await addSnapshotWebSocketEndpoint(sessionPath, { kind: "string", value: "ws://snapshot.test/chat" });
+    const endpoint = added.state.webSocket![0]!;
+    expect(endpoint).toMatchObject({
+      endpointId: "websocket:endpoint:string:ws://snapshot.test/chat:0",
+      info: { source: "temp", endpoint: "ws://snapshot.test/chat" },
+      enabled: true,
+    });
+    const withListener = await addSnapshotWebSocketListener(sessionPath, endpoint.endpointId, { preset: "send", options: { message: "hello" } });
+    const listener = withListener.state.webSocket![0]!.listeners[0]!;
+
+    await setSnapshotWebSocketEndpointEnabled(sessionPath, endpoint.endpointId, false);
+    await setSnapshotWebSocketListenerEnabled(sessionPath, listener.info.id, false);
+    await setSnapshotWebSocketListenerBehavior(sessionPath, listener.info.id, { preset: "close", options: { code: 4000 } });
+    await expect(getSnapshotWebSocketEndpoint(sessionPath, endpoint.endpointId)).resolves.toMatchObject({
+      enabled: false,
+      listeners: [{ enabled: false, behavior: { preset: "close", options: { code: 4000 } } }],
+    });
+
+    await removeSnapshotWebSocketListener(sessionPath, listener.info.id);
+    await removeSnapshotWebSocketEndpoint(sessionPath, endpoint.endpointId);
+    await expect(listSnapshotWebSocketEndpoints(sessionPath)).resolves.toEqual([]);
+  });
+
+  it("rejects invalid WebSocket targets and preserves code-source entries", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    const codeEndpoint = webSocketEndpointSchema.parse({
+      info: { id: "code-chat", kind: "websocket", endpoint: "ws://code.test/chat", operation: "endpoint", source: "code" },
+      endpointId: "code-chat",
+      matcher: { kind: "string", value: "ws://code.test/chat" },
+      enabled: true,
+      listeners: [{
+        info: { id: "code-chat:message:0", kind: "websocket", endpoint: "ws://code.test/chat", operation: "message", source: "code" },
+        endpointId: "code-chat", event: "message", enabled: true, behavior: { preset: "default" },
+      }],
+    });
+    await writeSnapshot(sessionPath, bumpSnapshot(createEmptySnapshot(), { webSocket: [codeEndpoint] }));
+
+    await expect(removeSnapshotWebSocketEndpoint(sessionPath, "code-chat")).rejects.toThrow("cannot be deleted");
+    await expect(removeSnapshotWebSocketListener(sessionPath, "code-chat:message:0")).rejects.toThrow("cannot be deleted");
+    await expect(setSnapshotWebSocketEndpointEnabled(sessionPath, "missing", false)).rejects.toThrow("not found");
+    await expect(addSnapshotWebSocketListener(sessionPath, "missing", { preset: "send" })).rejects.toThrow("not found");
+    await expect(removeSnapshotWebSocketListener(sessionPath, "missing")).rejects.toThrow("not found");
+    await expect(setSnapshotWebSocketListenerEnabled(sessionPath, "missing", false)).rejects.toThrow("not found");
+    await expect(setSnapshotWebSocketListenerBehavior(sessionPath, "missing", { preset: "close" })).rejects.toThrow("not found");
+    await expect(listSnapshotWebSocketEndpoints(sessionPath)).resolves.toEqual([codeEndpoint]);
+  });
+
+  it("preserves regexp matchers and allocates fresh endpoint and listener IDs", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await writeSnapshot(sessionPath, createEmptySnapshot());
+    const matcher = { kind: "string" as const, value: "ws://snapshot.test/chat" };
+
+    const first = (await addSnapshotWebSocketEndpoint(sessionPath, matcher)).state.webSocket![0]!;
+    const second = (await addSnapshotWebSocketEndpoint(sessionPath, matcher)).state.webSocket![1]!;
+    expect([first.endpointId, second.endpointId]).toEqual([
+      "websocket:endpoint:string:ws://snapshot.test/chat:0",
+      "websocket:endpoint:string:ws://snapshot.test/chat:1",
+    ]);
+
+    const firstListener = (await addSnapshotWebSocketListener(sessionPath, first.endpointId, { preset: "send", options: { message: "first" } }))
+      .state.webSocket![0]!.listeners[0]!;
+    const secondListener = (await addSnapshotWebSocketListener(sessionPath, first.endpointId, { preset: "send", options: { message: "second" } }))
+      .state.webSocket![0]!.listeners[1]!;
+    await removeSnapshotWebSocketListener(sessionPath, firstListener.info.id);
+    const replacement = (await addSnapshotWebSocketListener(sessionPath, first.endpointId, { preset: "send", options: { message: "replacement" } }))
+      .state.webSocket![0]!.listeners.find((listener) => listener.info.id !== secondListener.info.id)!;
+    expect(replacement.info.id).toBe(`${first.endpointId}:message:2`);
+
+    const regexp = await addSnapshotWebSocketEndpoint(sessionPath, {
+      kind: "regexp",
+      source: "snapshot\\.test/regex",
+      flags: "i",
+    });
+    expect(regexp.state.webSocket!.at(-1)!.info.endpoint).toBe("/snapshot\\.test/regex/i");
+  });
+
+  it("rejects invalid WebSocket mutations without changing the snapshot", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await writeSnapshot(sessionPath, createEmptySnapshot());
+    const endpoint = (await addSnapshotWebSocketEndpoint(sessionPath, {
+      kind: "string",
+      value: "ws://snapshot.test/chat",
+    })).state.webSocket![0]!;
+    const listener = (await addSnapshotWebSocketListener(sessionPath, endpoint.endpointId, {
+      preset: "send",
+      options: { message: "before" },
+    })).state.webSocket![0]!.listeners[0]!;
+
+    await expect(addSnapshotWebSocketEndpoint(sessionPath, {
+      kind: "regexp",
+      source: "snapshot.test",
+      flags: "invalid",
+    })).rejects.toThrow("WebSocket regular-expression matcher must be valid");
+    await expect(addSnapshotWebSocketListener(sessionPath, endpoint.endpointId, { preset: "send" }))
+      .rejects.toThrow();
+    await expect(setSnapshotWebSocketListenerBehavior(sessionPath, listener.info.id, { preset: "close", options: { code: "4000" } }))
+      .rejects.toThrow();
+
+    await expect(getSnapshotWebSocketEndpoint(sessionPath, endpoint.endpointId)).resolves.toMatchObject({
+      listeners: [{ behavior: { preset: "send", options: { message: "before" } } }],
+    });
+    await expect(listSnapshotWebSocketEndpoints(sessionPath)).resolves.toHaveLength(1);
+  });
+
+  it("serializes concurrent WebSocket endpoint mutations without lost updates", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await writeSnapshot(sessionPath, createEmptySnapshot());
+
+    await Promise.all(Array.from({ length: 2 }, (_, index) =>
+      addSnapshotWebSocketEndpoint(sessionPath, {
+        kind: "string",
+        value: `ws://snapshot.test/concurrent/${index}`,
+      })
+    ));
+
+    const endpoints = await listSnapshotWebSocketEndpoints(sessionPath);
+    expect(endpoints).toHaveLength(2);
+    expect(new Set(endpoints.map((endpoint) => endpoint.endpointId))).toHaveLength(2);
   });
 
   it("uses PID-named session files in the caller cwd", async () => {

--- a/packages/core/src/shared/schema/websocket.test.ts
+++ b/packages/core/src/shared/schema/websocket.test.ts
@@ -47,9 +47,20 @@ describe("websocket schema", () => {
     });
   });
 
-  it("rejects unsupported behavior presets", () => {
+  it("rejects invalid matchers and behavior options", () => {
+    expect(() => serializableWebSocketMatcherSchema.parse({
+      kind: "regexp",
+      source: "schema.test",
+      flags: "invalid",
+    })).toThrow("WebSocket regular-expression matcher must be valid");
+
     expect(() => webSocketBehaviorSchema.parse({
       preset: "reply",
-    })).toThrow("WebSocket behavior must be default, send, or close");
+    })).toThrow();
+    expect(() => webSocketBehaviorSchema.parse({ preset: "send" })).toThrow();
+    expect(() => webSocketBehaviorSchema.parse({
+      preset: "close",
+      options: { code: "4000" },
+    })).toThrow();
   });
 });

--- a/packages/core/src/shared/schema/websocket.test.ts
+++ b/packages/core/src/shared/schema/websocket.test.ts
@@ -63,4 +63,23 @@ describe("websocket schema", () => {
       options: { code: "4000" },
     })).toThrow();
   });
+
+  it("accepts only WebSocket-compatible close arguments", () => {
+    for (const code of [1000, 3000, 4999]) {
+      expect(() => webSocketBehaviorSchema.parse({ preset: "close", options: { code } })).not.toThrow();
+    }
+    for (const code of [999, 1001, 2999, 5000]) {
+      expect(() => webSocketBehaviorSchema.parse({ preset: "close", options: { code } }))
+        .toThrow("WebSocket close code must be 1000 or between 3000 and 4999");
+    }
+
+    expect(() => webSocketBehaviorSchema.parse({
+      preset: "close",
+      options: { reason: "€".repeat(41) },
+    })).not.toThrow();
+    expect(() => webSocketBehaviorSchema.parse({
+      preset: "close",
+      options: { reason: "€".repeat(41) + "a" },
+    })).toThrow("WebSocket close reason must not exceed 123 UTF-8 bytes");
+  });
 });

--- a/packages/core/src/shared/schema/websocket.ts
+++ b/packages/core/src/shared/schema/websocket.ts
@@ -2,20 +2,28 @@ import { z } from "zod";
 const webSocketInfoSchema = z.object({
   id: z.string(), kind: z.literal("websocket"), endpoint: z.string(), operation: z.string(), source: z.enum(["code", "temp"]),
 });
-export const webSocketBehaviorSchema = z.object({
-  preset: z.string().refine((value) => value === "default" || value === "send" || value === "close", {
-    message: "WebSocket behavior must be default, send, or close",
-  }),
-  options: z.unknown().optional(),
-});
-export const webSocketSendOptionsSchema = z.object({ message: z.string() });
+export const webSocketSendOptionsSchema = z.object({ message: z.string() }).strict();
 export const webSocketCloseOptionsSchema = z.object({
   code: z.number().int().optional(),
   reason: z.string().optional(),
-});
+}).strict();
+export const webSocketBehaviorSchema = z.union([
+  z.object({ preset: z.literal("default") }).strict(),
+  z.object({ preset: z.literal("send"), options: webSocketSendOptionsSchema }).strict(),
+  z.object({ preset: z.literal("close"), options: webSocketCloseOptionsSchema.optional() }).strict(),
+]);
 export const serializableWebSocketMatcherSchema = z.union([
   z.object({ kind: z.literal("string"), value: z.string() }),
-  z.object({ kind: z.literal("regexp"), source: z.string(), flags: z.string() }),
+  z.object({ kind: z.literal("regexp"), source: z.string(), flags: z.string() }).superRefine(({ source, flags }, context) => {
+    try {
+      new RegExp(source, flags);
+    } catch {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "WebSocket regular-expression matcher must be valid",
+      });
+    }
+  }),
 ]);
 export const webSocketListenerSchema = z.object({
   info: webSocketInfoSchema, endpointId: z.string(), event: z.literal("message"), enabled: z.boolean(), behavior: webSocketBehaviorSchema,

--- a/packages/core/src/shared/schema/websocket.ts
+++ b/packages/core/src/shared/schema/websocket.ts
@@ -4,8 +4,14 @@ const webSocketInfoSchema = z.object({
 });
 export const webSocketSendOptionsSchema = z.object({ message: z.string() }).strict();
 export const webSocketCloseOptionsSchema = z.object({
-  code: z.number().int().optional(),
-  reason: z.string().optional(),
+  code: z.number().int().refine(
+    (code) => code === 1000 || (code >= 3000 && code <= 4999),
+    "WebSocket close code must be 1000 or between 3000 and 4999"
+  ).optional(),
+  reason: z.string().refine(
+    (reason) => new TextEncoder().encode(reason).byteLength <= 123,
+    "WebSocket close reason must not exceed 123 UTF-8 bytes"
+  ).optional(),
 }).strict();
 export const webSocketBehaviorSchema = z.union([
   z.object({ preset: z.literal("default") }).strict(),

--- a/packages/example/app/api/ws/route.ts
+++ b/packages/example/app/api/ws/route.ts
@@ -1,0 +1,35 @@
+import { ensureMswServer } from "@/mocks/node";
+
+export const runtime = "nodejs";
+
+const waitForSocketResult = (target: string, message: string) => new Promise<
+  { type: "message"; data: string } | { type: "close"; code: number; reason: string }
+>((resolve, reject) => {
+  const socket = new WebSocket(target);
+  const timer = setTimeout(() => {
+    socket.close();
+    reject(new Error("WebSocket mock did not respond"));
+  }, 2_000);
+  socket.addEventListener("open", () => socket.send(message), { once: true });
+  socket.addEventListener("message", (event) => {
+    clearTimeout(timer);
+    socket.close();
+    resolve({ type: "message", data: String(event.data) });
+  }, { once: true });
+  socket.addEventListener("close", (event) => {
+    clearTimeout(timer);
+    resolve({ type: "close", code: event.code, reason: event.reason });
+  }, { once: true });
+  socket.addEventListener("error", () => {
+    clearTimeout(timer);
+    reject(new Error("WebSocket mock connection failed"));
+  }, { once: true });
+});
+
+export async function GET(request: Request) {
+  await ensureMswServer();
+  const url = new URL(request.url);
+  const target = url.searchParams.get("target") ?? "ws://node.example.local/chat";
+  const message = url.searchParams.get("message") ?? "hello";
+  return Response.json(await waitForSocketResult(target, message));
+}

--- a/packages/example/app/api/ws/route.ts
+++ b/packages/example/app/api/ws/route.ts
@@ -2,6 +2,8 @@ import { ensureMswServer } from "@/mocks/node";
 
 export const runtime = "nodejs";
 
+const APPROVED_SOCKET_TARGET = "ws://node.example.local/chat";
+
 const waitForSocketResult = (target: string, message: string) => new Promise<
   { type: "message"; data: string } | { type: "close"; code: number; reason: string }
 >((resolve, reject) => {
@@ -27,9 +29,13 @@ const waitForSocketResult = (target: string, message: string) => new Promise<
 });
 
 export async function GET(request: Request) {
-  await ensureMswServer();
   const url = new URL(request.url);
-  const target = url.searchParams.get("target") ?? "ws://node.example.local/chat";
+  const target = url.searchParams.get("target") ?? APPROVED_SOCKET_TARGET;
+  if (target !== APPROVED_SOCKET_TARGET) {
+    return Response.json({ error: "Unsupported WebSocket target" }, { status: 400 });
+  }
+
+  await ensureMswServer();
   const message = url.searchParams.get("message") ?? "hello";
   return Response.json(await waitForSocketResult(target, message));
 }

--- a/packages/example/src/mocks/node.ts
+++ b/packages/example/src/mocks/node.ts
@@ -1,12 +1,22 @@
 import { setupDevToolServer } from "@msw-dev-tool/core/node";
+import { ws } from "@msw-dev-tool/core/msw";
 import { handlers } from "./handlers";
 
 let serverPromise: ReturnType<typeof setupDevToolServer> | null = null;
 
+const chat = ws.link("ws://node.example.local/chat");
+const nodeWebSocketHandlers = [
+  chat.addEventListener("connection", ({ client }) => {
+    client.addEventListener("message", (event) => {
+      client.send(`echo:${String(event.data)}`);
+    });
+  }),
+];
+
 export const ensureMswServer = async () => {
   if (!serverPromise) {
     serverPromise = (async () => {
-      const server = await setupDevToolServer(...handlers);
+      const server = await setupDevToolServer(...handlers, ...nodeWebSocketHandlers);
       server.listen({ onUnhandledRequest: "bypass" });
       return server;
     })();

--- a/packages/node-cli/src/cli/session.test.ts
+++ b/packages/node-cli/src/cli/session.test.ts
@@ -1,18 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 
 const api = vi.hoisted(() => ({
-  addSnapshotTempHandler: vi.fn(), getSnapshotHandler: vi.fn(), listSnapshotHandlers: vi.fn(), readSessionSnapshot: vi.fn(),
+  addSnapshotTempHandler: vi.fn(), getSnapshotHandler: vi.fn(), listSnapshotHandlers: vi.fn(), readSnapshotOrEmpty: vi.fn(),
   removeSnapshotTempHandler: vi.fn(), requestSnapshotReset: vi.fn(), setSnapshotBehavior: vi.fn(), setSnapshotCustomResponse: vi.fn(),
+  addSnapshotWebSocketEndpoint: vi.fn(), addSnapshotWebSocketListener: vi.fn(), getSnapshotWebSocketEndpoint: vi.fn(), listSnapshotWebSocketEndpoints: vi.fn(),
+  removeSnapshotWebSocketEndpoint: vi.fn(), removeSnapshotWebSocketListener: vi.fn(), setSnapshotWebSocketEndpointEnabled: vi.fn(),
+  setSnapshotWebSocketListenerBehavior: vi.fn(), setSnapshotWebSocketListenerEnabled: vi.fn(),
 }));
 vi.mock("@msw-dev-tool/core/node/internal", () => api);
 import { FileSnapshotCliSession } from "./session";
 
 const snapshot = (handlers = [{ id: "a" }]) => ({ revision: 2, state: { flattenHandlers: handlers, pendingReset: false } });
+const wsEndpoint = {
+  endpointId: "ws-1",
+  info: { id: "ws-1", kind: "websocket" as const, endpoint: "ws://example.test/chat", operation: "endpoint", source: "temp" as const },
+  matcher: { kind: "string" as const, value: "ws://example.test/chat" },
+  enabled: true,
+  listeners: [],
+};
+const wsListener = {
+  info: { id: "ws-1:message:0", kind: "websocket" as const, endpoint: "ws://example.test/chat", operation: "message", source: "temp" as const },
+  endpointId: "ws-1", event: "message" as const, enabled: true, behavior: { preset: "send" },
+};
+const wsSnapshot = (endpoint = wsEndpoint) => ({ revision: 2, state: { flattenHandlers: [], webSocket: [endpoint] } });
 
 describe("FileSnapshotCliSession", () => {
   it("adapts reads and every mutation result", async () => {
     vi.useFakeTimers();
-    api.readSessionSnapshot.mockReturnValue(snapshot());
+    api.readSnapshotOrEmpty.mockReturnValue(snapshot());
     api.listSnapshotHandlers.mockReturnValue([{ id: "a" }]);
     api.getSnapshotHandler.mockReturnValue({ id: "a" });
     api.setSnapshotBehavior.mockReturnValue(snapshot());
@@ -30,17 +45,35 @@ describe("FileSnapshotCliSession", () => {
     vi.useRealTimers();
   });
 
-  it("rejects all WebSocket stub methods as not implemented", async () => {
+  it("adapts all WebSocket reads and mutations", async () => {
+    vi.useFakeTimers();
+    const endpointWithListener = { ...wsEndpoint, listeners: [wsListener] };
+    api.listSnapshotWebSocketEndpoints.mockResolvedValue([wsEndpoint]);
+    api.getSnapshotWebSocketEndpoint.mockResolvedValue(wsEndpoint);
+    api.addSnapshotWebSocketEndpoint.mockReturnValue(wsSnapshot());
+    api.removeSnapshotWebSocketEndpoint.mockReturnValue(wsSnapshot());
+    api.setSnapshotWebSocketEndpointEnabled.mockReturnValue(wsSnapshot());
+    api.addSnapshotWebSocketListener.mockReturnValue(wsSnapshot(endpointWithListener));
+    api.removeSnapshotWebSocketListener.mockReturnValue(wsSnapshot());
+    api.setSnapshotWebSocketListenerEnabled.mockReturnValue(wsSnapshot(endpointWithListener));
+    api.setSnapshotWebSocketListenerBehavior.mockReturnValue(wsSnapshot(endpointWithListener));
     const session = new FileSnapshotCliSession("/tmp/session.json");
-    await expect(session.listWebSocket()).rejects.toThrow("not implemented");
-    await expect(session.getWebSocketEndpoint("id")).rejects.toThrow("not implemented");
-    await expect(session.addWebSocketEndpoint({ kind: "string", value: "ws://localhost" })).rejects.toThrow("not implemented");
-    await expect(session.removeWebSocketEndpoint("id")).rejects.toThrow("not implemented");
-    await expect(session.setWebSocketEndpointEnabled("id", true)).rejects.toThrow("not implemented");
-    await expect(session.addWebSocketListener("id", { preset: "send" })).rejects.toThrow("not implemented");
-    await expect(session.removeWebSocketListener("id")).rejects.toThrow("not implemented");
-    await expect(session.setWebSocketListenerEnabled("id", true)).rejects.toThrow("not implemented");
-    await expect(session.setWebSocketListenerBehavior("id", { preset: "close" })).rejects.toThrow("not implemented");
+    await expect(session.listWebSocket()).resolves.toEqual([wsEndpoint]);
+    await expect(session.getWebSocketEndpoint("ws-1")).resolves.toEqual(wsEndpoint);
+    const calls = [
+      session.addWebSocketEndpoint(wsEndpoint.matcher),
+      session.removeWebSocketEndpoint("ws-1"),
+      session.setWebSocketEndpointEnabled("ws-1", false),
+      session.addWebSocketListener("ws-1", { preset: "send" }),
+      session.removeWebSocketListener(wsListener.info.id),
+      session.setWebSocketListenerEnabled(wsListener.info.id, false),
+      session.setWebSocketListenerBehavior(wsListener.info.id, { preset: "close" }),
+    ];
+    await vi.advanceTimersByTimeAsync(300);
+    await expect(Promise.all(calls)).resolves.toHaveLength(7);
+    expect(api.addSnapshotWebSocketEndpoint).toHaveBeenCalledWith("/tmp/session.json", wsEndpoint.matcher);
+    expect(api.setSnapshotWebSocketListenerBehavior).toHaveBeenCalledWith("/tmp/session.json", wsListener.info.id, { preset: "close" });
+    vi.useRealTimers();
   });
 
   it("reports mutations that cannot find the resulting handler", async () => {

--- a/packages/node-cli/src/cli/session.ts
+++ b/packages/node-cli/src/cli/session.ts
@@ -1,12 +1,21 @@
 import {
   addSnapshotTempHandler,
+  addSnapshotWebSocketEndpoint,
+  addSnapshotWebSocketListener,
   getSnapshotHandler,
+  getSnapshotWebSocketEndpoint,
   listSnapshotHandlers,
-  readSessionSnapshot,
+  listSnapshotWebSocketEndpoints,
+  readSnapshotOrEmpty,
   removeSnapshotTempHandler,
+  removeSnapshotWebSocketEndpoint,
+  removeSnapshotWebSocketListener,
   requestSnapshotReset,
   setSnapshotBehavior,
   setSnapshotCustomResponse,
+  setSnapshotWebSocketEndpointEnabled,
+  setSnapshotWebSocketListenerBehavior,
+  setSnapshotWebSocketListenerEnabled,
 } from "@msw-dev-tool/core/node/internal";
 import { CliSession } from "@msw-dev-tool/cli-core";
 
@@ -21,7 +30,7 @@ const toInfo = (snapshot: { revision: number; state: { pendingReset?: boolean; f
 /** File-backed adapter for Node snapshot envelopes. */
 export class FileSnapshotCliSession implements CliSession {
   public constructor(private readonly sessionPath: string) {}
-  public async describe() { return toInfo(await readSessionSnapshot(this.sessionPath)); }
+  public async describe() { return toInfo(await readSnapshotOrEmpty(this.sessionPath)); }
   public async list() { return listSnapshotHandlers(this.sessionPath); }
   public async get(id: string) { return getSnapshotHandler(this.sessionPath, id); }
   public async setBehavior(id: string, behavior: Parameters<typeof setSnapshotBehavior>[2]) {
@@ -53,15 +62,61 @@ export class FileSnapshotCliSession implements CliSession {
   public async reset() {
     await requestSnapshotReset(this.sessionPath);
     await settleAfterWrite();
-    return toInfo(await readSessionSnapshot(this.sessionPath));
+    return toInfo(await readSnapshotOrEmpty(this.sessionPath));
   }
-  public async listWebSocket(): Promise<never[]> { throw new Error("not implemented"); }
-  public async getWebSocketEndpoint(): Promise<undefined> { throw new Error("not implemented"); }
-  public async addWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
-  public async removeWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
-  public async setWebSocketEndpointEnabled(): Promise<never> { throw new Error("not implemented"); }
-  public async addWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
-  public async removeWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
-  public async setWebSocketListenerEnabled(): Promise<never> { throw new Error("not implemented"); }
-  public async setWebSocketListenerBehavior(): Promise<never> { throw new Error("not implemented"); }
+  public listWebSocket() { return listSnapshotWebSocketEndpoints(this.sessionPath); }
+  public getWebSocketEndpoint(endpointId: string) {
+    return getSnapshotWebSocketEndpoint(this.sessionPath, endpointId);
+  }
+  public async addWebSocketEndpoint(matcher: Parameters<typeof addSnapshotWebSocketEndpoint>[1]) {
+    const snapshot = await addSnapshotWebSocketEndpoint(this.sessionPath, matcher);
+    await settleAfterWrite();
+    return { endpoint: snapshot.state.webSocket!.at(-1)! };
+  }
+  public async removeWebSocketEndpoint(endpointId: string) {
+    const snapshot = await removeSnapshotWebSocketEndpoint(this.sessionPath, endpointId);
+    await settleAfterWrite();
+    return { endpoints: snapshot.state.webSocket ?? [] };
+  }
+  public async setWebSocketEndpointEnabled(
+    endpointId: string,
+    enabled: boolean
+  ) {
+    const snapshot = await setSnapshotWebSocketEndpointEnabled(this.sessionPath, endpointId, enabled);
+    await settleAfterWrite();
+    return { endpoint: snapshot.state.webSocket!.find((endpoint) => endpoint.endpointId === endpointId)! };
+  }
+  public async addWebSocketListener(
+    endpointId: string,
+    behavior: Parameters<typeof addSnapshotWebSocketListener>[2]
+  ) {
+    const snapshot = await addSnapshotWebSocketListener(this.sessionPath, endpointId, behavior);
+    await settleAfterWrite();
+    const endpoint = snapshot.state.webSocket!.find((entry) => entry.endpointId === endpointId)!;
+    return { endpoint, listener: endpoint.listeners.at(-1)! };
+  }
+  public async removeWebSocketListener(listenerId: string) {
+    const snapshot = await removeSnapshotWebSocketListener(this.sessionPath, listenerId);
+    await settleAfterWrite();
+    return { endpoints: snapshot.state.webSocket ?? [] };
+  }
+  public async setWebSocketListenerEnabled(listenerId: string, enabled: boolean) {
+    const snapshot = await setSnapshotWebSocketListenerEnabled(this.sessionPath, listenerId, enabled);
+    await settleAfterWrite();
+    const endpoint = snapshot.state.webSocket!.find((entry) =>
+      entry.listeners.some((listener) => listener.info.id === listenerId)
+    )!;
+    return { endpoint, listener: endpoint.listeners.find((listener) => listener.info.id === listenerId)! };
+  }
+  public async setWebSocketListenerBehavior(
+    listenerId: string,
+    behavior: Parameters<typeof setSnapshotWebSocketListenerBehavior>[2]
+  ) {
+    const snapshot = await setSnapshotWebSocketListenerBehavior(this.sessionPath, listenerId, behavior);
+    await settleAfterWrite();
+    const endpoint = snapshot.state.webSocket!.find((entry) =>
+      entry.listeners.some((listener) => listener.info.id === listenerId)
+    )!;
+    return { endpoint, listener: endpoint.listeners.find((listener) => listener.info.id === listenerId)! };
+  }
 }


### PR DESCRIPTION
## Abstract

Enable the Node CLI to manage WebSocket endpoints and listeners through the running process’s snapshot session.
## Issues

Closes #154

## Description

WebSocket operations therefore follow the same locked read-modify-write protocol as HTTP handler mutations: each command observes persisted state, produces stable IDs for later commands, and leaves unrelated endpoint/listener configuration intact.

Validation now occurs before configuration crosses the persistence boundary. Regular-expression matchers must be constructible by the runtime, and listener behavior is validated against its preset-specific payload. A successful command consequently represents configuration that the runtime can actually apply; rejected input cannot leave a dormant or malformed snapshot behind.

The example Node route provides a real WebSocket request path for exercising the cross-process synchronization model, rather than treating the session file as a purely structural artifact.

## Additional Context

The adapter keeps the existing post-write settling window so a CLI invocation does not race the runtime’s file watcher before the next command or observable client behavior. Lock retry tolerance was increased for bursts of independent CLI processes; this favors preserving each successful mutation over prematurely failing during ordinary contention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing WebSocket endpoints and message listeners in snapshots.
  * WebSocket endpoints and listeners can now be created, removed, enabled, disabled, and configured with custom behaviors.
  * Added a WebSocket example route that sends messages and returns responses or close details.

* **Bug Fixes**
  * Improved validation for WebSocket behavior options and regular-expression matchers.
  * Increased lock acquisition retries to improve reliability during contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->