### PR TITLE
feat(browser-cli): manage WebSocket sessions over CDP

### DIFF
--- a/.changeset/browser-cli-websocket-session.md
+++ b/.changeset/browser-cli-websocket-session.md
@@ -1,0 +1,6 @@
+---
+"@msw-dev-tool/core": minor
+"@msw-dev-tool/browser-cli": minor
+---
+
+Add WebSocket endpoint and listener management through Browser CLI CDP sessions.

--- a/packages/browser-cli/src/cdp.test.ts
+++ b/packages/browser-cli/src/cdp.test.ts
@@ -17,6 +17,11 @@ describe("listTargets", () => {
     await expect(listTargets("http://localhost:9222")).rejects.toThrow("Failed to list Chrome targets: 503 Unavailable");
   });
 
+  it("preserves a non-timeout fetch failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Chrome is unavailable")));
+    await expect(listTargets("http://localhost:9222")).rejects.toThrow("Chrome is unavailable");
+  });
+
   it("times out instead of leaving an agent command waiting for Chrome", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("fetch", vi.fn().mockImplementation((_: URL, options: RequestInit) =>
@@ -43,6 +48,43 @@ describe("CdpClient", () => {
     const client = await CdpClient.connect(`ws://127.0.0.1:${address.port}`);
     try {
       await expect(client.call("Runtime.evaluate")).rejects.toThrow("CDP connection closed");
+    } finally {
+      client.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("rejects an in-flight command when Chrome reports a protocol error", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP test server address");
+    server.on("connection", (socket) => socket.once("message", () => {
+      socket.send(JSON.stringify({ id: 1, error: { message: "Runtime disabled" } }));
+    }));
+
+    const client = await CdpClient.connect(`ws://127.0.0.1:${address.port}`);
+    try {
+      await expect(client.call("Runtime.evaluate")).rejects.toThrow("CDP error: Runtime disabled");
+    } finally {
+      client.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("ignores malformed CDP frames and continues with the next valid response", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP test server address");
+    server.on("connection", (socket) => socket.once("message", () => {
+      socket.send("not-json");
+      socket.send(JSON.stringify({ id: 1, result: { value: "ok" } }));
+    }));
+
+    const client = await CdpClient.connect(`ws://127.0.0.1:${address.port}`);
+    try {
+      await expect(client.call("Runtime.evaluate")).resolves.toEqual({ value: "ok" });
     } finally {
       client.close();
       await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/packages/browser-cli/src/session.test.ts
+++ b/packages/browser-cli/src/session.test.ts
@@ -114,16 +114,61 @@ describe("CdpBrowserCliSession", () => {
     await expect(new CdpBrowserCliSession(client).describe()).rejects.toThrow("CDP evaluation failed");
   });
 
-  it("rejects all WebSocket stub methods as not implemented", async () => {
-    const session = new CdpBrowserCliSession({ call: vi.fn() } as unknown as CdpClient);
-    await expect(session.listWebSocket()).rejects.toThrow("not implemented");
-    await expect(session.getWebSocketEndpoint("id")).rejects.toThrow("not implemented");
-    await expect(session.addWebSocketEndpoint({ kind: "string", value: "ws://localhost" })).rejects.toThrow("not implemented");
-    await expect(session.removeWebSocketEndpoint("id")).rejects.toThrow("not implemented");
-    await expect(session.setWebSocketEndpointEnabled("id", true)).rejects.toThrow("not implemented");
-    await expect(session.addWebSocketListener("id", { preset: "send" })).rejects.toThrow("not implemented");
-    await expect(session.removeWebSocketListener("id")).rejects.toThrow("not implemented");
-    await expect(session.setWebSocketListenerEnabled("id", true)).rejects.toThrow("not implemented");
-    await expect(session.setWebSocketListenerBehavior("id", { preset: "close" })).rejects.toThrow("not implemented");
+  it("forwards every WebSocket operation with serializable arguments", async () => {
+    const listWebSocket = vi.fn(() => []);
+    const getWebSocketEndpoint = vi.fn(() => undefined);
+    const addWebSocketEndpoint = vi.fn(() => ({ endpoint: { endpointId: "endpoint-a" } }));
+    const removeWebSocketEndpoint = vi.fn(() => ({ endpoints: [] }));
+    const setWebSocketEndpointEnabled = vi.fn(() => ({ endpoint: { endpointId: "endpoint-a" } }));
+    const addWebSocketListener = vi.fn(() => ({ endpoint: { endpointId: "endpoint-a" }, listener: { info: { id: "listener-a" } } }));
+    const removeWebSocketListener = vi.fn(() => ({ endpoints: [] }));
+    const setWebSocketListenerEnabled = vi.fn(() => ({ endpoint: { endpointId: "endpoint-a" }, listener: { info: { id: "listener-a" } } }));
+    const setWebSocketListenerBehavior = vi.fn(() => ({ endpoint: { endpointId: "endpoint-a" }, listener: { info: { id: "listener-a" } } }));
+    const { client, call } = createEvaluatingClient({
+      methods: {
+        listWebSocket: 1, getWebSocketEndpoint: 1, addWebSocketEndpoint: 1,
+        removeWebSocketEndpoint: 1, setWebSocketEndpointEnabled: 1, addWebSocketListener: 1,
+        removeWebSocketListener: 1, setWebSocketListenerEnabled: 1, setWebSocketListenerBehavior: 1,
+      },
+      listWebSocket, getWebSocketEndpoint, addWebSocketEndpoint, removeWebSocketEndpoint,
+      setWebSocketEndpointEnabled, addWebSocketListener, removeWebSocketListener,
+      setWebSocketListenerEnabled, setWebSocketListenerBehavior,
+    });
+    const session = new CdpBrowserCliSession(client);
+    const matcher = { kind: "regexp" as const, source: "browser\\.example", flags: "i" };
+    const behavior = { preset: "send", options: { message: "hello" } } as const;
+
+    await expect(session.listWebSocket()).resolves.toEqual([]);
+    await expect(session.getWebSocketEndpoint("endpoint-a")).resolves.toBeUndefined();
+    await session.addWebSocketEndpoint(matcher);
+    await session.removeWebSocketEndpoint("endpoint-a");
+    await session.setWebSocketEndpointEnabled("endpoint-a", false);
+    await session.addWebSocketListener("endpoint-a", behavior);
+    await session.removeWebSocketListener("listener-a");
+    await session.setWebSocketListenerEnabled("listener-a", false);
+    await session.setWebSocketListenerBehavior("listener-a", { preset: "close", options: { code: 4001, reason: "done" } });
+
+    expect(addWebSocketEndpoint).toHaveBeenCalledWith(matcher);
+    expect(addWebSocketListener).toHaveBeenCalledWith("endpoint-a", behavior);
+    expect(call).toHaveBeenCalledTimes(9);
+    expect(call.mock.calls[2]?.[1].expression).toContain('"source":"browser\\\\.example"');
+    expect(call.mock.calls[4]?.[1].expression).toContain("false");
+  });
+
+  it.each([
+    ["the capability manifest is missing", {}, true],
+    ["the WebSocket method version is incompatible", { methods: { addWebSocketEndpoint: 2 } }, true],
+    ["the WebSocket method implementation is missing", { methods: { addWebSocketEndpoint: 1 } }, false],
+  ])("rejects WebSocket invocation when %s", async (_scenario, bridge, includeImplementation) => {
+    const addWebSocketEndpoint = vi.fn();
+    const { client } = createEvaluatingClient({
+      ...bridge,
+      ...(includeImplementation ? { addWebSocketEndpoint } : {}),
+    });
+
+    await expect(new CdpBrowserCliSession(client).addWebSocketEndpoint({ kind: "string", value: "ws://localhost" })).rejects.toThrow(
+      'MSW Dev Tool browser control method "addWebSocketEndpoint" version 1 is unavailable. Update @msw-dev-tool/core.'
+    );
+    expect(addWebSocketEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/packages/browser-cli/src/session.ts
+++ b/packages/browser-cli/src/session.ts
@@ -1,9 +1,20 @@
-import { CliHandler, CliMutationResult, CliSession, CliSessionInfo } from "@msw-dev-tool/cli-core";
+import {
+  CliHandler,
+  CliMutationResult,
+  CliSession,
+  CliSessionInfo,
+  CliWebSocketEndpointResult,
+  CliWebSocketInfo,
+  CliWebSocketListenerResult,
+} from "@msw-dev-tool/cli-core";
 import {
   BROWSER_CONTROL_KEY,
   CustomResponse,
   HttpHandlerBehavior,
+  SerializableWebSocketMatcher,
   TempHandlerInput,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
 } from "@msw-dev-tool/core/shared";
 import { CdpClient } from "./cdp";
 
@@ -18,6 +29,15 @@ const REQUIRED_BROWSER_CONTROL_METHOD_VERSIONS = {
   addTemp: 1,
   removeTemp: 1,
   reset: 1,
+  listWebSocket: 1,
+  getWebSocketEndpoint: 1,
+  addWebSocketEndpoint: 1,
+  removeWebSocketEndpoint: 1,
+  setWebSocketEndpointEnabled: 1,
+  addWebSocketListener: 1,
+  removeWebSocketListener: 1,
+  setWebSocketListenerEnabled: 1,
+  setWebSocketListenerBehavior: 1,
 } as const;
 
 type BrowserControlMethod = keyof typeof REQUIRED_BROWSER_CONTROL_METHOD_VERSIONS;
@@ -45,13 +65,29 @@ export class CdpBrowserCliSession implements CliSession {
   public addTemp(data: TempHandlerInput): Promise<CliMutationResult> { return this.invoke("addTemp", [data]); }
   public removeTemp(id: string): Promise<CliSessionInfo> { return this.invoke("removeTemp", [id]); }
   public reset(): Promise<CliSessionInfo> { return this.invoke("reset"); }
-  public async listWebSocket(): Promise<never[]> { throw new Error("not implemented"); }
-  public async getWebSocketEndpoint(): Promise<undefined> { throw new Error("not implemented"); }
-  public async addWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
-  public async removeWebSocketEndpoint(): Promise<never> { throw new Error("not implemented"); }
-  public async setWebSocketEndpointEnabled(): Promise<never> { throw new Error("not implemented"); }
-  public async addWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
-  public async removeWebSocketListener(): Promise<never> { throw new Error("not implemented"); }
-  public async setWebSocketListenerEnabled(): Promise<never> { throw new Error("not implemented"); }
-  public async setWebSocketListenerBehavior(): Promise<never> { throw new Error("not implemented"); }
+  public listWebSocket(): Promise<WebSocketEndpointConfig[]> { return this.invoke("listWebSocket"); }
+  public getWebSocketEndpoint(endpointId: string): Promise<WebSocketEndpointConfig | undefined> {
+    return this.invoke("getWebSocketEndpoint", [endpointId]);
+  }
+  public addWebSocketEndpoint(matcher: SerializableWebSocketMatcher): Promise<CliWebSocketEndpointResult> {
+    return this.invoke("addWebSocketEndpoint", [matcher]);
+  }
+  public removeWebSocketEndpoint(endpointId: string): Promise<CliWebSocketInfo> {
+    return this.invoke("removeWebSocketEndpoint", [endpointId]);
+  }
+  public setWebSocketEndpointEnabled(endpointId: string, enabled: boolean): Promise<CliWebSocketEndpointResult> {
+    return this.invoke("setWebSocketEndpointEnabled", [endpointId, enabled]);
+  }
+  public addWebSocketListener(endpointId: string, behavior: WebSocketBehaviorSelection): Promise<CliWebSocketListenerResult> {
+    return this.invoke("addWebSocketListener", [endpointId, behavior]);
+  }
+  public removeWebSocketListener(listenerId: string): Promise<CliWebSocketInfo> {
+    return this.invoke("removeWebSocketListener", [listenerId]);
+  }
+  public setWebSocketListenerEnabled(listenerId: string, enabled: boolean): Promise<CliWebSocketListenerResult> {
+    return this.invoke("setWebSocketListenerEnabled", [listenerId, enabled]);
+  }
+  public setWebSocketListenerBehavior(listenerId: string, behavior: WebSocketBehaviorSelection): Promise<CliWebSocketListenerResult> {
+    return this.invoke("setWebSocketListenerBehavior", [listenerId, behavior]);
+  }
 }

--- a/packages/cli-core/src/index.test.ts
+++ b/packages/cli-core/src/index.test.ts
@@ -178,4 +178,20 @@ describe("shared CLI commands", () => {
     await expect(findCommand("set-behavior")!.execute(context, { flags: {}, positionals: ["set-behavior", "a", "bad"] })).rejects.toThrow("Unknown behavior");
     await expect(findCommand("add-temp")!.execute(context, { flags: {}, positionals: ["add-temp"] })).rejects.toThrow("Usage");
   });
+
+  it("rejects invalid custom response JSON and schema before session mutation", async () => {
+    const session = createSession();
+    session.setCustomResponse = vi.fn();
+    const context = { session };
+    await expect(findCommand("set-custom-response")!.execute(context, {
+      flags: { json: "{bad}" }, positionals: ["set-custom-response", "handler-a"],
+    })).rejects.toThrow("Custom response must be valid JSON");
+    await expect(findCommand("set-custom-response")!.execute(context, {
+      flags: { json: "{\"status\":\"wrong\"}" }, positionals: ["set-custom-response", "handler-a"],
+    })).rejects.toThrow();
+    await expect(findCommand("set-custom-response")!.execute(context, {
+      flags: {}, positionals: ["set-custom-response", "handler-a"],
+    })).rejects.toThrow("Usage: set-custom-response");
+    expect(session.setCustomResponse).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -111,6 +111,50 @@ describe("browser control bridge", () => {
     });
   });
 
+  it("exposes WebSocket endpoint and listener mutations through the browser bridge", async () => {
+    await setupDevToolWorker();
+    const bridge = getBridge();
+    const added = bridge.addWebSocketEndpoint({
+      kind: "regexp",
+      source: "browser\\.example\\.local/cli-e2e",
+      flags: "i",
+    });
+    const listener = bridge.addWebSocketListener(added.endpoint.endpointId, {
+      preset: "send",
+      options: { message: "hello" },
+    });
+
+    expect(bridge.listWebSocket()).toEqual([expect.objectContaining({
+      endpointId: added.endpoint.endpointId,
+      matcher: { kind: "regexp", source: "browser\\.example\\.local/cli-e2e", flags: "i" },
+    })]);
+    expect(bridge.getWebSocketEndpoint(added.endpoint.endpointId)).toEqual(listener.endpoint);
+    expect(bridge.setWebSocketEndpointEnabled(added.endpoint.endpointId, false).endpoint.enabled).toBe(false);
+    expect(bridge.setWebSocketListenerEnabled(listener.listener.info.id, false).listener.enabled).toBe(false);
+    expect(bridge.setWebSocketListenerBehavior(listener.listener.info.id, { preset: "close", options: { code: 4001 } }).listener.behavior).toEqual({
+      preset: "close", options: { code: 4001 },
+    });
+    const persistedBeforeInvalidBehavior = sessionStorage.getItem(STORAGE_KEY);
+    expect(() => bridge.addWebSocketListener(added.endpoint.endpointId, { preset: "invalid" })).toThrow();
+    expect(() => bridge.setWebSocketListenerBehavior(listener.listener.info.id, { preset: "invalid" })).toThrow();
+    expect(bridge.getWebSocketEndpoint(added.endpoint.endpointId)?.listeners).toEqual([
+      expect.objectContaining({ behavior: { preset: "close", options: { code: 4001 } } }),
+    ]);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe(persistedBeforeInvalidBehavior);
+    expect(bridge.removeWebSocketListener(listener.listener.info.id).endpoints[0]?.listeners).toEqual([]);
+    expect(bridge.removeWebSocketEndpoint(added.endpoint.endpointId).endpoints).toEqual([]);
+    const matcher = { kind: "string" as const, value: "ws://browser.test/load" };
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => Promise.resolve().then(() => bridge.addWebSocketEndpoint(matcher)))
+    );
+
+    expect(new Set(results.map((result) => result.endpoint.endpointId)).size).toBe(20);
+    expect(bridge.listWebSocket()).toHaveLength(20);
+    expect(() => bridge.removeWebSocketEndpoint("missing-endpoint")).toThrow(
+      "WebSocket endpoint not found: missing-endpoint"
+    );
+  });
+
   it("keeps HTTP temp metadata when hydrating WebSocket state", async () => {
     await setupDevToolWorker(http.get("/hydrate", () => HttpResponse.json({ ok: true })));
     const state = handlerStore.getState();

--- a/packages/core/src/browser/handlerStore.ts
+++ b/packages/core/src/browser/handlerStore.ts
@@ -14,7 +14,8 @@ import {
   BrowserControlBridge,
 } from "../shared/controlProtocol";
 import { HandlerSchema } from "./schema";
-import { tempHandlerSchema } from "../shared/schema";
+import { tempHandlerSchema, webSocketBehaviorSchema } from "../shared/schema";
+import { webSocketEndpointFromMatcher } from "../shared/websocket/state";
 import { getBrowserStorageSnapshot, mergeStorageData } from "./storage";
 
 export { BROWSER_CONTROL_KEY, BrowserControlBridge } from "../shared/controlProtocol";
@@ -174,6 +175,18 @@ const requireHandler = (id: string) => {
   return handler;
 };
 
+const requireWebSocketEndpoint = (id: string) => {
+  const endpoint = handlerStore.getState().getWebSocketEndpoint(id);
+  if (!endpoint) throw new Error(`WebSocket endpoint not found: ${id}`);
+  return endpoint;
+};
+
+const requireWebSocketListener = (id: string) => {
+  const listener = handlerStore.getState().getWebSocketListener(id);
+  if (!listener) throw new Error(`WebSocket listener not found: ${id}`);
+  return listener;
+};
+
 const registerBrowserControlBridge = () => {
   if (typeof window === "undefined") return;
   const bridge: BrowserControlBridge = {
@@ -207,6 +220,47 @@ const registerBrowserControlBridge = () => {
     reset: () => {
       handlerStore.getState().resetMSWDevTool();
       return describeBrowserSession();
+    },
+    listWebSocket: () => handlerStore.getState().webSocket.endpoints,
+    getWebSocketEndpoint: (endpointId) => handlerStore.getState().getWebSocketEndpoint(endpointId),
+    addWebSocketEndpoint: (matcher) => {
+      const endpointId = handlerStore.getState().addTempWebSocketEndpoint({
+        matcher,
+        endpoint: webSocketEndpointFromMatcher(matcher),
+      });
+      return { endpoint: requireWebSocketEndpoint(endpointId) };
+    },
+    removeWebSocketEndpoint: (endpointId) => {
+      handlerStore.getState().removeWebSocketEndpoint(endpointId);
+      return { endpoints: handlerStore.getState().webSocket.endpoints };
+    },
+    setWebSocketEndpointEnabled: (endpointId, enabled) => {
+      handlerStore.getState().setWebSocketEndpointEnabled(endpointId, enabled);
+      return { endpoint: requireWebSocketEndpoint(endpointId) };
+    },
+    addWebSocketListener: (endpointId, behavior) => {
+      const listenerId = handlerStore.getState().addTempWebSocketListener({
+        endpointId,
+        behavior: webSocketBehaviorSchema.parse(behavior),
+      });
+      return { endpoint: requireWebSocketEndpoint(endpointId), listener: requireWebSocketListener(listenerId) };
+    },
+    removeWebSocketListener: (listenerId) => {
+      handlerStore.getState().removeWebSocketListener(listenerId);
+      return { endpoints: handlerStore.getState().webSocket.endpoints };
+    },
+    setWebSocketListenerEnabled: (listenerId, enabled) => {
+      handlerStore.getState().setWebSocketListenerEnabled(listenerId, enabled);
+      const listener = requireWebSocketListener(listenerId);
+      return { endpoint: requireWebSocketEndpoint(listener.endpointId), listener };
+    },
+    setWebSocketListenerBehavior: (listenerId, behavior) => {
+      handlerStore.getState().setWebSocketListenerBehavior(
+        listenerId,
+        webSocketBehaviorSchema.parse(behavior)
+      );
+      const listener = requireWebSocketListener(listenerId);
+      return { endpoint: requireWebSocketEndpoint(listener.endpointId), listener };
     },
   };
   window[BROWSER_CONTROL_KEY] = bridge;

--- a/packages/core/src/browser/react.test.tsx
+++ b/packages/core/src/browser/react.test.tsx
@@ -12,6 +12,14 @@ function UnstableSelectorComponent() {
   return <span data-testid="ids">{ids.length}</span>;
 }
 
+function SelectorChangeComponent({ selectCount }: { selectCount: boolean }) {
+  const value = useHandlerStore(selectCount
+    ? (state) => state.flattenHandlers.length
+    : (state) => state.restHandlers.length
+  );
+  return <span data-testid="value">{value}</span>;
+}
+
 describe("useHandlerStore", () => {
   it("does not loop when selector returns a new array reference", async () => {
     const container = document.createElement("div");
@@ -28,5 +36,14 @@ describe("useHandlerStore", () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it("recomputes when a caller supplies a new selector", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => root.render(<SelectorChangeComponent selectCount />));
+    await act(async () => root.render(<SelectorChangeComponent selectCount={false} />));
+    expect(container.querySelector("[data-testid='value']")?.textContent).toBe("0");
+    await act(async () => root.unmount());
   });
 });

--- a/packages/core/src/browser/storage.test.ts
+++ b/packages/core/src/browser/storage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { STORAGE_KEY } from "../shared/const";
 import {
   CustomBehavior,
@@ -13,6 +13,8 @@ describe("getStorageData", () => {
   beforeEach(() => {
     sessionStorage.clear();
   });
+
+  afterEach(() => vi.unstubAllGlobals());
 
   it("returns empty flattenHandlers when key is missing", () => {
     expect(getStorageData()).toEqual({ flattenHandlers: [] });
@@ -109,6 +111,15 @@ describe("getStorageData", () => {
     expect(() => getBrowserStorageSnapshot()).toThrow(
       `Invalid msw-dev-tool sessionStorage payload for key "${STORAGE_KEY}": Expected number, received string`
     );
+  });
+
+  it("reports invalid JSON and supports SSR without sessionStorage", () => {
+    sessionStorage.setItem(STORAGE_KEY, "{");
+    expect(() => getBrowserStorageSnapshot()).toThrow("invalid JSON");
+
+    vi.stubGlobal("sessionStorage", undefined);
+    expect(getBrowserStorageSnapshot()).toEqual({ revision: 0, state: { flattenHandlers: [] } });
+    expect(getStorageData()).toEqual({ flattenHandlers: [] });
   });
 });
 

--- a/packages/core/src/browser/validate.test.ts
+++ b/packages/core/src/browser/validate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isValidHtml, isValidUrl, isValidXml } from "./validate";
 
 describe("isValidUrl", () => {
@@ -16,5 +16,13 @@ describe("isValidXml / isValidHtml", () => {
   it("accepts well-formed markup documents", () => {
     expect(isValidXml("<root></root>")).toBe(true);
     expect(isValidHtml("<div></div>")).toBe(true);
+  });
+
+  it("returns false when DOM parsing throws", () => {
+    const spy = vi.spyOn(DOMParser.prototype, "parseFromString").mockImplementation(() => {
+      throw new Error("parser unavailable");
+    });
+    expect(isValidXml("<root />")).toBe(false);
+    spy.mockRestore();
   });
 });

--- a/packages/core/src/node/snapshot/controller.test.ts
+++ b/packages/core/src/node/snapshot/controller.test.ts
@@ -36,6 +36,13 @@ afterEach(() => {
 });
 
 describe("SessionController", () => {
+  it("does nothing when synchronized before start", async () => {
+    const onSnapshot = vi.fn();
+    const controller = new SessionController({ onSnapshot, onReset: () => [] });
+    await expect(controller.sync()).resolves.toBeUndefined();
+    expect(onSnapshot).not.toHaveBeenCalled();
+  });
+
   it("seeds a session and applies each newer non-reset snapshot once", async () => {
     const sessionPath = createTempSessionPath();
     const onSnapshot = vi.fn();
@@ -210,4 +217,5 @@ describe("SessionController", () => {
     expect(onSnapshot).toHaveBeenCalledOnce();
     await controller.dispose();
   });
+
 });

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -85,13 +85,6 @@ export class SessionController {
       return;
     }
 
-    if (snapshot.revision < this.lastWrittenRevision) {
-      console.warn(
-        `[msw-dev-tool] snapshot revision ${snapshot.revision} is older than last written revision ${this.lastWrittenRevision}; ignoring`
-      );
-      return;
-    }
-
     if (snapshot.state.pendingReset) {
       const flattenHandlers = this.options.onReset();
       const webSocket = this.options.onResetWebSocket?.() ?? previousWebSocket(snapshot);

--- a/packages/core/src/node/snapshot/mutations.ts
+++ b/packages/core/src/node/snapshot/mutations.ts
@@ -1,21 +1,22 @@
 import { getRowId } from "../../shared/utils/store";
 import {
   CustomResponse,
-  HttpHandlerBehavior,
-  SerializableWebSocketMatcher,
-  TempHandlerInput,
-  WebSocketBehaviorSelection,
-  WebSocketEndpointConfig,
+  HttpHandlerBehavior, TempHandlerInput, WebSocketEndpointConfig,
 } from "../../shared/types";
 import {
-  webSocketEndpointSchema,
-  webSocketBehaviorSchema,
-  webSocketListenerSchema,
-} from "../../shared/schema/websocket";
+  addTemporaryWebSocketEndpoint,
+  addTemporaryWebSocketListener,
+  removeTemporaryWebSocketEndpoint,
+  removeTemporaryWebSocketListener,
+  setWebSocketEndpointEnabled,
+  setWebSocketListenerBehavior,
+  setWebSocketListenerEnabled,
+} from "../../shared/websocket/state";
 import {
-  createWebSocketEndpointId,
-  createWebSocketListenerId,
-} from "../../shared/store/webSocketSlice";
+  serializableWebSocketMatcherSchema,
+  webSocketBehaviorSchema,
+  webSocketEndpointsSchema,
+} from "../../shared/schema/websocket";
 import { bumpSnapshot } from "./serialize";
 import { readSnapshotOrEmpty, withLockedMutation } from "./file";
 import { SessionSnapshot, SerializableFlattenHandler } from "./types";
@@ -34,9 +35,6 @@ type SnapshotWebSocketEndpoint = NonNullable<SessionSnapshot["state"]["webSocket
 const snapshotWebSocketEndpoints = (snapshot: SessionSnapshot): SnapshotWebSocketEndpoint[] =>
   snapshot.state.webSocket ?? [];
 
-const endpointFromMatcher = (matcher: SerializableWebSocketMatcher): string =>
-  matcher.kind === "string" ? matcher.value : `/${matcher.source}/${matcher.flags}`;
-
 export const listSnapshotWebSocketEndpoints = async (
   sessionPath: string
 ): Promise<WebSocketEndpointConfig[]> => snapshotWebSocketEndpoints(await readSnapshotOrEmpty(sessionPath));
@@ -49,42 +47,21 @@ export const getSnapshotWebSocketEndpoint = async (
 
 export const addSnapshotWebSocketEndpoint = (
   sessionPath: string,
-  matcher: SerializableWebSocketMatcher
+  matcher: WebSocketEndpointConfig["matcher"]
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  let index = 0;
-  let endpointId = `${createWebSocketEndpointId(matcher)}:${index}`;
-  while (endpoints.some((endpoint) => endpoint.endpointId === endpointId)) {
-    index += 1;
-    endpointId = `${createWebSocketEndpointId(matcher)}:${index}`;
-  }
-  const endpoint = webSocketEndpointSchema.parse({
-    info: {
-      id: endpointId,
-      kind: "websocket",
-      endpoint: endpointFromMatcher(matcher),
-      operation: "endpoint",
-      source: "temp",
-    },
-    endpointId,
-    matcher,
-    enabled: true,
-    listeners: [],
-  });
-  return bumpSnapshot(prev, { webSocket: [...endpoints, endpoint] });
+  const next = addTemporaryWebSocketEndpoint(
+    snapshotWebSocketEndpoints(prev),
+    serializableWebSocketMatcherSchema.parse(matcher)
+  );
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const removeSnapshotWebSocketEndpoint = (
   sessionPath: string,
   endpointId: string
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  const endpoint = endpoints.find((entry) => entry.endpointId === endpointId);
-  if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
-  if (endpoint.info.source !== "temp") {
-    throw new Error(`WebSocket endpoints generated from codebase cannot be deleted (id: ${endpointId})`);
-  }
-  return bumpSnapshot(prev, { webSocket: endpoints.filter((entry) => entry.endpointId !== endpointId) });
+  const next = removeTemporaryWebSocketEndpoint(snapshotWebSocketEndpoints(prev), endpointId);
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const setSnapshotWebSocketEndpointEnabled = (
@@ -92,66 +69,32 @@ export const setSnapshotWebSocketEndpointEnabled = (
   endpointId: string,
   enabled: boolean
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  if (!endpoints.some((endpoint) => endpoint.endpointId === endpointId)) {
-    throw new Error(`WebSocket endpoint not found: ${endpointId}`);
-  }
-  return bumpSnapshot(prev, {
-    webSocket: endpoints.map((endpoint) => endpoint.endpointId === endpointId ? { ...endpoint, enabled } : endpoint),
-  });
+  const next = setWebSocketEndpointEnabled(snapshotWebSocketEndpoints(prev), endpointId, enabled);
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const addSnapshotWebSocketListener = (
   sessionPath: string,
   endpointId: string,
-  behavior: WebSocketBehaviorSelection
+  behavior: WebSocketEndpointConfig["listeners"][number]["behavior"]
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  const endpoint = endpoints.find((entry) => entry.endpointId === endpointId);
-  if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
-  let index = endpoint.listeners.length;
-  let listenerId = createWebSocketListenerId(endpointId, index);
-  const listeners = endpoints.flatMap((entry) => entry.listeners);
-  while (listeners.some((listener) => listener.info.id === listenerId)) {
-    index += 1;
-    listenerId = createWebSocketListenerId(endpointId, index);
+  if (!snapshotWebSocketEndpoints(prev).some((endpoint) => endpoint.endpointId === endpointId)) {
+    throw new Error(`WebSocket endpoint not found: ${endpointId}`);
   }
-  const listener = webSocketListenerSchema.parse({
-    info: {
-      id: listenerId,
-      kind: "websocket" as const,
-      endpoint: endpoint.info.endpoint,
-      operation: "message",
-      source: "temp" as const,
-    },
+  const next = addTemporaryWebSocketListener(
+    snapshotWebSocketEndpoints(prev),
     endpointId,
-    event: "message" as const,
-    enabled: true,
-    behavior,
-  });
-  return bumpSnapshot(prev, {
-    webSocket: endpoints.map((entry) => entry.endpointId === endpointId
-      ? { ...entry, listeners: [...entry.listeners, listener] }
-      : entry),
-  });
+    webSocketBehaviorSchema.parse(behavior)
+  );
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const removeSnapshotWebSocketListener = (
   sessionPath: string,
   listenerId: string
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  const listener = endpoints.flatMap((endpoint) => endpoint.listeners).find((entry) => entry.info.id === listenerId);
-  if (!listener) throw new Error(`WebSocket listener not found: ${listenerId}`);
-  if (listener.info.source !== "temp") {
-    throw new Error(`WebSocket listeners generated from codebase cannot be deleted (id: ${listenerId})`);
-  }
-  return bumpSnapshot(prev, {
-    webSocket: endpoints.map((endpoint) => ({
-      ...endpoint,
-      listeners: endpoint.listeners.filter((entry) => entry.info.id !== listenerId),
-    })),
-  });
+  const next = removeTemporaryWebSocketListener(snapshotWebSocketEndpoints(prev), listenerId);
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const setSnapshotWebSocketListenerEnabled = (
@@ -159,34 +102,26 @@ export const setSnapshotWebSocketListenerEnabled = (
   listenerId: string,
   enabled: boolean
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  if (!endpoints.some((endpoint) => endpoint.listeners.some((listener) => listener.info.id === listenerId))) {
-    throw new Error(`WebSocket listener not found: ${listenerId}`);
-  }
-  return bumpSnapshot(prev, {
-    webSocket: endpoints.map((endpoint) => ({
-      ...endpoint,
-      listeners: endpoint.listeners.map((listener) => listener.info.id === listenerId ? { ...listener, enabled } : listener),
-    })),
-  });
+  const next = setWebSocketListenerEnabled(snapshotWebSocketEndpoints(prev), listenerId, enabled);
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const setSnapshotWebSocketListenerBehavior = (
   sessionPath: string,
   listenerId: string,
-  behavior: WebSocketBehaviorSelection
+  behavior: WebSocketEndpointConfig["listeners"][number]["behavior"]
 ): Promise<SessionSnapshot> => withLockedMutation(sessionPath, (prev) => {
-  const endpoints = snapshotWebSocketEndpoints(prev);
-  if (!endpoints.some((endpoint) => endpoint.listeners.some((listener) => listener.info.id === listenerId))) {
+  if (!snapshotWebSocketEndpoints(prev).some((endpoint) =>
+    endpoint.listeners.some((listener) => listener.info.id === listenerId)
+  )) {
     throw new Error(`WebSocket listener not found: ${listenerId}`);
   }
-  const nextBehavior = webSocketBehaviorSchema.parse(behavior);
-  return bumpSnapshot(prev, {
-    webSocket: endpoints.map((endpoint) => ({
-      ...endpoint,
-      listeners: endpoint.listeners.map((listener) => listener.info.id === listenerId ? { ...listener, behavior: nextBehavior } : listener),
-    })),
-  });
+  const next = setWebSocketListenerBehavior(
+    snapshotWebSocketEndpoints(prev),
+    listenerId,
+    webSocketBehaviorSchema.parse(behavior)
+  );
+  return bumpSnapshot(prev, { webSocket: webSocketEndpointsSchema.parse(next.endpoints) });
 });
 
 export const setSnapshotBehavior = (

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -29,6 +29,7 @@ import {
   getSessionPathForPid,
   listSessionPids,
   applySnapshotToRuntime,
+  SnapshotRepository,
 } from "./index";
 import {
   HttpHandlerBehavior,
@@ -56,6 +57,17 @@ afterEach(() => {
 });
 
 describe("snapshot file protocol", () => {
+  it("exercises the SnapshotRepository read, write, and mutation boundary", async () => {
+    const dir = makeTempDir();
+    const repository = new SnapshotRepository(path.join(dir, "session.json"));
+    await expect(repository.read()).resolves.toBeNull();
+    await expect(repository.readOrEmpty()).resolves.toEqual(createEmptySnapshot());
+
+    await repository.write(createEmptySnapshot());
+    const next = await repository.mutate((snapshot) => bumpSnapshot(snapshot, { flattenHandlers: [] }));
+    await expect(repository.read()).resolves.toEqual(next);
+  });
+
   it("writes and reads snapshots atomically", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");

--- a/packages/core/src/shared/controlProtocol.ts
+++ b/packages/core/src/shared/controlProtocol.ts
@@ -1,5 +1,12 @@
 import { CustomResponse, HttpHandlerBehavior } from "./types";
-import type { PersistedFlattenHandler, TempHandlerInput } from "./types";
+import type {
+  PersistedFlattenHandler,
+  SerializableWebSocketMatcher,
+  TempHandlerInput,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
+  WebSocketListenerConfig,
+} from "./types";
 
 /** Global property used by a CDP client to discover a configured browser session. */
 export const BROWSER_CONTROL_KEY = "__MSW_DEV_TOOL_CONTROL__";
@@ -16,6 +23,15 @@ export const BROWSER_CONTROL_METHOD_VERSIONS = {
   addTemp: 1,
   removeTemp: 1,
   reset: 1,
+  listWebSocket: 1,
+  getWebSocketEndpoint: 1,
+  addWebSocketEndpoint: 1,
+  removeWebSocketEndpoint: 1,
+  setWebSocketEndpointEnabled: 1,
+  addWebSocketListener: 1,
+  removeWebSocketListener: 1,
+  setWebSocketListenerEnabled: 1,
+  setWebSocketListenerBehavior: 1,
 } as const;
 
 export type BrowserControlMethod = keyof typeof BROWSER_CONTROL_METHOD_VERSIONS;
@@ -30,6 +46,13 @@ export type BrowserControlMutationResult = BrowserControlSessionInfo & {
   handler: PersistedFlattenHandler;
 };
 
+export type BrowserControlWebSocketInfo = { endpoints: WebSocketEndpointConfig[] };
+export type BrowserControlWebSocketEndpointResult = { endpoint: WebSocketEndpointConfig };
+export type BrowserControlWebSocketListenerResult = {
+  endpoint: WebSocketEndpointConfig;
+  listener: WebSocketListenerConfig;
+};
+
 export type BrowserControlBridge = {
   /** @deprecated Kept for compatibility with older Browser CLI versions. */
   version: typeof BROWSER_CONTROL_PROTOCOL_VERSION;
@@ -42,4 +65,13 @@ export type BrowserControlBridge = {
   addTemp: (data: TempHandlerInput) => BrowserControlMutationResult;
   removeTemp: (id: string) => BrowserControlSessionInfo;
   reset: () => BrowserControlSessionInfo;
+  listWebSocket: () => WebSocketEndpointConfig[];
+  getWebSocketEndpoint: (endpointId: string) => WebSocketEndpointConfig | undefined;
+  addWebSocketEndpoint: (matcher: SerializableWebSocketMatcher) => BrowserControlWebSocketEndpointResult;
+  removeWebSocketEndpoint: (endpointId: string) => BrowserControlWebSocketInfo;
+  setWebSocketEndpointEnabled: (endpointId: string, enabled: boolean) => BrowserControlWebSocketEndpointResult;
+  addWebSocketListener: (endpointId: string, behavior: WebSocketBehaviorSelection) => BrowserControlWebSocketListenerResult;
+  removeWebSocketListener: (listenerId: string) => BrowserControlWebSocketInfo;
+  setWebSocketListenerEnabled: (listenerId: string, enabled: boolean) => BrowserControlWebSocketListenerResult;
+  setWebSocketListenerBehavior: (listenerId: string, behavior: WebSocketBehaviorSelection) => BrowserControlWebSocketListenerResult;
 };

--- a/packages/core/src/shared/store/webSocketSlice.ts
+++ b/packages/core/src/shared/store/webSocketSlice.ts
@@ -7,6 +7,16 @@ import type {
   WebSocketListenerConfig,
   WebSocketHandlerInfo,
 } from "../types";
+import {
+  addTemporaryWebSocketEndpoint,
+  addTemporaryWebSocketListener,
+  removeTemporaryWebSocketEndpoint,
+  removeTemporaryWebSocketListener,
+  resetWebSocketEndpoints,
+  setWebSocketEndpointEnabled,
+  setWebSocketListenerBehavior,
+  setWebSocketListenerEnabled,
+} from "../websocket/state";
 
 export type WebSocketRuntimeAdapter = {
   addTempEndpoint?: (config: WebSocketEndpointConfig) => void;
@@ -20,24 +30,11 @@ export type WebSocketStoreState = {
   listeners: WebSocketListenerConfig[];
 };
 
-export const canonicalWebSocketMatcher = (
-  matcher: SerializableWebSocketMatcher
-): string => matcher.kind === "string"
-  ? `string:${matcher.value}`
-  : `regexp:${matcher.source}/${matcher.flags}`;
-
 const defaultBehavior: WebSocketBehaviorSelection = { preset: "default" };
-
-export const createWebSocketEndpointId = (matcher: SerializableWebSocketMatcher) =>
-  `websocket:endpoint:${canonicalWebSocketMatcher(matcher)}`;
-
-export const createWebSocketListenerId = (endpointId: string, index: number) =>
-  `${endpointId}:message:${index}`;
+export { canonicalWebSocketMatcher, createWebSocketEndpointId, createWebSocketListenerId } from "../websocket/state";
 
 export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
   let state: WebSocketStoreState = { endpoints: [], listeners: [] };
-  let endpointOrder = 0;
-
   const getEndpoint = (id: string) => state.endpoints.find((entry) => entry.endpointId === id);
   const getListener = (id: string) => state.listeners.find((entry) => entry.info.id === id);
   const set = (next: WebSocketStoreState) => { state = next; };
@@ -66,59 +63,39 @@ export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
       registerListener({ ...input, enabled: true, behavior: defaultBehavior });
     },
     addTempEndpoint: (input: { matcher: SerializableWebSocketMatcher; endpoint: string }) => {
-      let endpointId = "";
-      do {
-        endpointId = `${createWebSocketEndpointId(input.matcher)}:${endpointOrder++}`;
-      } while (state.endpoints.some((entry) => entry.endpointId === endpointId));
-      const info: WebSocketHandlerInfo = { id: endpointId, kind: "websocket", endpoint: input.endpoint, operation: "endpoint", source: "temp" };
-      const config: WebSocketEndpointConfig = { info, endpointId, matcher: input.matcher, enabled: true, listeners: [] };
-      set({ ...state, endpoints: [...state.endpoints, config] });
-      runtime?.addTempEndpoint?.(config);
-      return endpointId;
+      const next = addTemporaryWebSocketEndpoint(state.endpoints, input.matcher, input.endpoint);
+      set({ ...state, endpoints: next.endpoints });
+      runtime?.addTempEndpoint?.(next.endpoint);
+      return next.endpoint.endpointId;
     },
     addTempListener: (input: { endpointId: string; behavior: WebSocketBehaviorSelection }) => {
-      const endpoint = getEndpoint(input.endpointId);
-      if (!endpoint) throw new Error(`WebSocket endpoint not found: ${input.endpointId}`);
-      let index = endpoint.listeners.length;
-      let listenerId = createWebSocketListenerId(input.endpointId, index);
-      while (getListener(listenerId)) {
-        index += 1;
-        listenerId = createWebSocketListenerId(input.endpointId, index);
-      }
-      const listener: WebSocketListenerConfig = {
-        info: { id: listenerId, kind: "websocket", endpoint: endpoint.info.endpoint, operation: "message", source: "temp" },
-        endpointId: input.endpointId, event: "message", enabled: true, behavior: input.behavior,
-      };
-      registerListener(listener);
-      return listenerId;
+      const next = addTemporaryWebSocketListener(state.endpoints, input.endpointId, input.behavior);
+      set({ endpoints: next.endpoints, listeners: [...state.listeners, next.listener] });
+      return next.listener.info.id;
     },
     removeEndpoint: (endpointId: string) => {
-      const endpoint = getEndpoint(endpointId);
-      if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
-      if (endpoint.info.source !== "temp") throw new Error(`WebSocket endpoints generated from codebase cannot be deleted (id: ${endpointId})`);
+      const next = removeTemporaryWebSocketEndpoint(state.endpoints, endpointId);
       runtime?.closeEndpointConnections?.(endpointId);
       runtime?.removeEndpoint?.(endpointId);
-      const listenerIds = new Set(endpoint.listeners.map((entry) => entry.info.id));
-      set({ endpoints: state.endpoints.filter((entry) => entry.endpointId !== endpointId), listeners: state.listeners.filter((entry) => !listenerIds.has(entry.info.id)) });
+      const listenerIds = new Set(next.endpoint.listeners.map((entry) => entry.info.id));
+      set({ endpoints: next.endpoints, listeners: state.listeners.filter((entry) => !listenerIds.has(entry.info.id)) });
     },
     removeListener: (listenerId: string) => {
-      const listener = getListener(listenerId);
-      if (!listener) throw new Error(`WebSocket listener not found: ${listenerId}`);
-      if (listener.info.source !== "temp") throw new Error(`WebSocket listeners generated from codebase cannot be deleted (id: ${listenerId})`);
-      set({ endpoints: state.endpoints.map((entry) => ({ ...entry, listeners: entry.listeners.filter((item) => item.info.id !== listenerId) })), listeners: state.listeners.filter((entry) => entry.info.id !== listenerId) });
+      const next = removeTemporaryWebSocketListener(state.endpoints, listenerId);
+      set({ endpoints: next.endpoints, listeners: state.listeners.filter((entry) => entry.info.id !== listenerId) });
     },
     setEndpointEnabled: (endpointId: string, enabled: boolean) => {
-      if (!getEndpoint(endpointId)) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+      const next = setWebSocketEndpointEnabled(state.endpoints, endpointId, enabled);
       if (!enabled) runtime?.closeEndpointConnections?.(endpointId);
-      set({ ...state, endpoints: state.endpoints.map((entry) => entry.endpointId === endpointId ? { ...entry, enabled } : entry) });
+      set({ ...state, endpoints: next.endpoints });
     },
     setListenerEnabled: (listenerId: string, enabled: boolean) => {
-      if (!getListener(listenerId)) throw new Error(`WebSocket listener not found: ${listenerId}`);
-      set({ endpoints: state.endpoints.map((endpoint) => ({ ...endpoint, listeners: endpoint.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, enabled } : entry) })), listeners: state.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, enabled } : entry) });
+      const next = setWebSocketListenerEnabled(state.endpoints, listenerId, enabled);
+      set({ endpoints: next.endpoints, listeners: state.listeners.map((entry) => entry.info.id === listenerId ? next.listener : entry) });
     },
     setListenerBehavior: (listenerId: string, behavior: WebSocketBehaviorSelection) => {
-      if (!getListener(listenerId)) throw new Error(`WebSocket listener not found: ${listenerId}`);
-      set({ endpoints: state.endpoints.map((endpoint) => ({ ...endpoint, listeners: endpoint.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, behavior } : entry) })), listeners: state.listeners.map((entry) => entry.info.id === listenerId ? { ...entry, behavior } : entry) });
+      const next = setWebSocketListenerBehavior(state.endpoints, listenerId, behavior);
+      set({ endpoints: next.endpoints, listeners: state.listeners.map((entry) => entry.info.id === listenerId ? next.listener : entry) });
     },
     replace: (next: WebSocketEndpointConfig[]) => {
       set({ endpoints: next, listeners: next.flatMap((entry) => entry.listeners) });
@@ -132,7 +109,8 @@ export const createWebSocketSlice = (runtime?: WebSocketRuntimeAdapter) => {
     },
     reset: () => {
       runtime?.resetTempEndpoints?.();
-      state = { endpoints: state.endpoints.filter((entry) => entry.info.source === "code").map((entry) => ({ ...entry, listeners: entry.listeners.filter((listener) => listener.info.source === "code") })), listeners: state.listeners.filter((entry) => entry.info.source === "code") };
+      const endpoints = resetWebSocketEndpoints(state.endpoints);
+      state = { endpoints, listeners: endpoints.flatMap((entry) => entry.listeners) };
     },
   };
 };

--- a/packages/core/src/shared/websocket/state.ts
+++ b/packages/core/src/shared/websocket/state.ts
@@ -1,0 +1,174 @@
+import {
+  webSocketEndpointSchema,
+} from "../schema/websocket";
+import type {
+  SerializableWebSocketMatcher,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
+  WebSocketListenerConfig,
+} from "../types";
+
+export const canonicalWebSocketMatcher = (matcher: SerializableWebSocketMatcher): string =>
+  matcher.kind === "string"
+    ? `string:${matcher.value}`
+    : `regexp:${matcher.source}/${matcher.flags}`;
+
+export const createWebSocketEndpointId = (matcher: SerializableWebSocketMatcher) =>
+  `websocket:endpoint:${canonicalWebSocketMatcher(matcher)}`;
+
+export const createWebSocketListenerId = (endpointId: string, index: number) =>
+  `${endpointId}:message:${index}`;
+
+export const webSocketEndpointFromMatcher = (matcher: SerializableWebSocketMatcher): string =>
+  matcher.kind === "string" ? matcher.value : `/${matcher.source}/${matcher.flags}`;
+
+const findEndpoint = (endpoints: WebSocketEndpointConfig[], endpointId: string) => {
+  const endpoint = endpoints.find((entry) => entry.endpointId === endpointId);
+  if (!endpoint) throw new Error(`WebSocket endpoint not found: ${endpointId}`);
+  return endpoint;
+};
+
+const findListener = (endpoints: WebSocketEndpointConfig[], listenerId: string) => {
+  const endpoint = endpoints.find((entry) =>
+    entry.listeners.some((listener) => listener.info.id === listenerId)
+  );
+  const listener = endpoint?.listeners.find((entry) => entry.info.id === listenerId);
+  if (!endpoint || !listener) throw new Error(`WebSocket listener not found: ${listenerId}`);
+  return { endpoint, listener };
+};
+
+export const addTemporaryWebSocketEndpoint = (
+  endpoints: WebSocketEndpointConfig[],
+  matcherInput: SerializableWebSocketMatcher,
+  endpoint = webSocketEndpointFromMatcher(matcherInput)
+) => {
+  const matcher = matcherInput;
+  let index = 0;
+  let endpointId = `${createWebSocketEndpointId(matcher)}:${index}`;
+  while (endpoints.some((entry) => entry.endpointId === endpointId)) {
+    index += 1;
+    endpointId = `${createWebSocketEndpointId(matcher)}:${index}`;
+  }
+  const created = webSocketEndpointSchema.parse({
+    info: { id: endpointId, kind: "websocket", endpoint, operation: "endpoint", source: "temp" },
+    endpointId,
+    matcher,
+    enabled: true,
+    listeners: [],
+  });
+  return { endpoints: [...endpoints, created], endpoint: created };
+};
+
+export const removeTemporaryWebSocketEndpoint = (
+  endpoints: WebSocketEndpointConfig[],
+  endpointId: string
+) => {
+  const endpoint = findEndpoint(endpoints, endpointId);
+  if (endpoint.info.source !== "temp") {
+    throw new Error(`WebSocket endpoints generated from codebase cannot be deleted (id: ${endpointId})`);
+  }
+  return { endpoints: endpoints.filter((entry) => entry.endpointId !== endpointId), endpoint };
+};
+
+export const setWebSocketEndpointEnabled = (
+  endpoints: WebSocketEndpointConfig[],
+  endpointId: string,
+  enabled: boolean
+) => {
+  findEndpoint(endpoints, endpointId);
+  const nextEndpoints = endpoints.map((entry) =>
+    entry.endpointId === endpointId ? { ...entry, enabled } : entry
+  );
+  return { endpoints: nextEndpoints, endpoint: findEndpoint(nextEndpoints, endpointId) };
+};
+
+export const addTemporaryWebSocketListener = (
+  endpoints: WebSocketEndpointConfig[],
+  endpointId: string,
+  behaviorInput: WebSocketBehaviorSelection
+) => {
+  const endpoint = findEndpoint(endpoints, endpointId);
+  const behavior = behaviorInput;
+  let index = endpoint.listeners.length;
+  let listenerId = createWebSocketListenerId(endpointId, index);
+  const listeners = endpoints.flatMap((entry) => entry.listeners);
+  while (listeners.some((listener) => listener.info.id === listenerId)) {
+    index += 1;
+    listenerId = createWebSocketListenerId(endpointId, index);
+  }
+  const listener: WebSocketListenerConfig = {
+    info: { id: listenerId, kind: "websocket", endpoint: endpoint.info.endpoint, operation: "message", source: "temp" },
+    endpointId,
+    event: "message",
+    enabled: true,
+    behavior,
+  };
+  const nextEndpoints = endpoints.map((entry) =>
+    entry.endpointId === endpointId ? { ...entry, listeners: [...entry.listeners, listener] } : entry
+  );
+  return { endpoints: nextEndpoints, endpoint: findEndpoint(nextEndpoints, endpointId), listener };
+};
+
+export const removeTemporaryWebSocketListener = (
+  endpoints: WebSocketEndpointConfig[],
+  listenerId: string
+) => {
+  const { listener } = findListener(endpoints, listenerId);
+  if (listener.info.source !== "temp") {
+    throw new Error(`WebSocket listeners generated from codebase cannot be deleted (id: ${listenerId})`);
+  }
+  return {
+    endpoints: endpoints.map((endpoint) => ({
+      ...endpoint,
+      listeners: endpoint.listeners.filter((entry) => entry.info.id !== listenerId),
+    })),
+    listener,
+  };
+};
+
+export const setWebSocketListenerEnabled = (
+  endpoints: WebSocketEndpointConfig[],
+  listenerId: string,
+  enabled: boolean
+) => {
+  findListener(endpoints, listenerId);
+  const nextEndpoints = endpoints.map((endpoint) => ({
+    ...endpoint,
+    listeners: endpoint.listeners.map((entry) =>
+      entry.info.id === listenerId ? { ...entry, enabled } : entry
+    ),
+  }));
+  const { endpoint, listener } = findListener(nextEndpoints, listenerId);
+  return { endpoints: nextEndpoints, endpoint, listener };
+};
+
+export const setWebSocketListenerBehavior = (
+  endpoints: WebSocketEndpointConfig[],
+  listenerId: string,
+  behaviorInput: WebSocketBehaviorSelection
+) => {
+  findListener(endpoints, listenerId);
+  const behavior = behaviorInput;
+  const nextEndpoints = endpoints.map((endpoint) => ({
+    ...endpoint,
+    listeners: endpoint.listeners.map((entry) =>
+      entry.info.id === listenerId ? { ...entry, behavior } : entry
+    ),
+  }));
+  const { endpoint, listener } = findListener(nextEndpoints, listenerId);
+  return { endpoints: nextEndpoints, endpoint, listener };
+};
+
+export const resetWebSocketEndpoints = (endpoints: WebSocketEndpointConfig[]) =>
+  endpoints
+    .filter((entry) => entry.info.source === "code")
+    .map((entry) => ({
+      ...entry,
+      listeners: entry.listeners.filter((listener) => listener.info.source === "code"),
+    }));
+
+export type WebSocketStateMutation = {
+  endpoints: WebSocketEndpointConfig[];
+  endpoint?: WebSocketEndpointConfig;
+  listener?: WebSocketListenerConfig;
+};

--- a/packages/example/src/components/BrowserWebSocketProbe.tsx
+++ b/packages/example/src/components/BrowserWebSocketProbe.tsx
@@ -14,8 +14,8 @@ export const BrowserWebSocketProbe = () => {
     const socket = new WebSocket(ENDPOINT);
     let finished = false;
     const timer = window.setTimeout(() => {
+      finish("timeout");
       socket.close();
-      setResult("timeout");
     }, 2_000);
     const finish = (next: Result) => {
       if (finished) return;

--- a/packages/example/src/components/BrowserWebSocketProbe.tsx
+++ b/packages/example/src/components/BrowserWebSocketProbe.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+const ENDPOINT = "ws://browser.example.local/cli-e2e";
+
+type Result = "idle" | "connecting" | `message: ${string}` | `close: ${number} ${string}` | "timeout" | "error";
+
+export const BrowserWebSocketProbe = () => {
+  const [result, setResult] = useState<Result>("idle");
+
+  const connect = () => {
+    setResult("connecting");
+    const socket = new WebSocket(ENDPOINT);
+    let finished = false;
+    const timer = window.setTimeout(() => {
+      socket.close();
+      setResult("timeout");
+    }, 2_000);
+    const finish = (next: Result) => {
+      if (finished) return;
+      finished = true;
+      window.clearTimeout(timer);
+      setResult(next);
+    };
+    socket.addEventListener("open", () => socket.send("ping"), { once: true });
+    socket.addEventListener("message", (event) => {
+      socket.close();
+      finish(`message: ${String(event.data)}`);
+    }, { once: true });
+    socket.addEventListener("close", (event) => finish(`close: ${event.code} ${event.reason}`), { once: true });
+    socket.addEventListener("error", () => finish("error"), { once: true });
+  };
+
+  return (
+    <section>
+      <h3>Browser WebSocket CLI probe</h3>
+      <p>Endpoint: <code>{ENDPOINT}</code></p>
+      <button type="button" onClick={connect}>Connect WebSocket</button>
+      <output aria-live="polite">{result}</output>
+    </section>
+  );
+};

--- a/packages/example/src/components/ClientMockingSection.tsx
+++ b/packages/example/src/components/ClientMockingSection.tsx
@@ -3,6 +3,7 @@
 import { UserList } from "./UserList";
 import { UserInfo } from "./UserInfo";
 import { OtherHostUserList } from "./OtherHostUserList";
+import { BrowserWebSocketProbe } from "./BrowserWebSocketProbe";
 
 export const ClientMockingSection = () => {
   return (
@@ -11,6 +12,7 @@ export const ClientMockingSection = () => {
       <UserList />
       <UserInfo />
       <OtherHostUserList />
+      <BrowserWebSocketProbe />
     </div>
   );
 };

--- a/packages/node-cli/src/cli.test.ts
+++ b/packages/node-cli/src/cli.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("node-cli executable", () => {
+  it("prints a JSON error and exits non-zero when the CLI rejects", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    vi.doMock("./run", () => ({ runCli: vi.fn().mockRejectedValue(new Error("broken session")) }));
+
+    await import("./cli");
+    await flush();
+
+    expect(stderr).toHaveBeenCalledWith(`${JSON.stringify({ ok: false, error: "broken session" })}\n`);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("serializes non-Error rejection values", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    vi.doMock("./run", () => ({ runCli: vi.fn().mockRejectedValue("broken") }));
+
+    await import("./cli");
+    await flush();
+
+    expect(stderr).toHaveBeenCalledWith(`${JSON.stringify({ ok: false, error: "broken" })}\n`);
+  });
+});

--- a/packages/node-cli/src/run.test.ts
+++ b/packages/node-cli/src/run.test.ts
@@ -85,5 +85,13 @@ describe("node-cli", () => {
     const { pid } = createSessionFile();
     await expect(runCli(["--pid", String(pid), "get"])).rejects.toThrow("Usage: get <id>");
     await expect(runCli(["--pid", "not-a-pid", "list"])).rejects.toThrow("--pid must be a numeric process ID");
+    await expect(runCli(["--pid", "999999", "list"])).rejects.toThrow("No msw-dev-tool session found for PID 999999");
+  });
+
+  it("reports that no session is available when discovery is empty", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msw-dev-tool-cli-empty-"));
+    tempDirs.push(dir);
+    process.chdir(dir);
+    await expect(runCli(["list"])).rejects.toThrow("No msw-dev-tool sessions found");
   });
 });


### PR DESCRIPTION
## Abstract

Add WebSocket endpoint and listener management to Browser CLI sessions, allowing a selected Chrome tab to be controlled through the same WebSocket command model already available to Node CLI sessions.

## Issues

close #155

## Description

- Extend the browser control bridge with versioned WebSocket capabilities for listing, reading, creating, removing, enabling, disabling, and updating endpoints and message listeners.
- Implement the Browser CLI CDP session methods so WebSocket commands are evaluated against the selected browser target.
- Extract shared WebSocket state transitions used by both the browser store and Node snapshot mutations, keeping endpoint/listener IDs, temporary-resource rules, and reset behavior aligned across transports.
- Validate listener behaviors at the browser control boundary before they can become persisted browser session state.
- Add a browser WebSocket probe to the example app so a tab can expose connection, message, close, timeout, and error outcomes while being controlled through Browser CLI.
- Include a changeset for the Core and Browser CLI package releases.

## Additional Context

The browser control bridge advertises capabilities per method. Browser CLI checks the required method version before invoking it, so a newer CLI can report an actionable compatibility error when attached to an older application bundle.

WebSocket state remains scoped to the selected CDP target. This preserves independent endpoint and listener state when multiple tabs are open.

The command behavior and state model follow the Node CLI implementation from #154, while CDP remains the browser-specific transport.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket endpoint and listener management, including creation, removal, enablement, and behavior updates.
  * Added WebSocket support to browser control sessions and CLI workflows.
  * Added an example WebSocket connection probe with status, error, and timeout reporting.

* **Bug Fixes**
  * Improved handling of protocol errors, malformed messages, missing resources, and invalid configurations.
  * Improved CLI error reporting and session discovery messages.

* **Tests**
  * Expanded coverage for WebSocket operations, storage, validation, snapshots, and selector updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->