### PR TITLE
feat: add React WebSocket controls

### DIFF
--- a/.changeset/bright-otters-rest.md
+++ b/.changeset/bright-otters-rest.md
@@ -1,0 +1,6 @@
+---
+"@msw-dev-tool/core": patch
+"@msw-dev-tool/react": minor
+---
+
+Add WebSocket endpoint and message-listener controls to the React dev tool. Temporary WebSocket listeners now require a send or close default action.

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -137,6 +137,12 @@ describe("browser control bridge", () => {
     const persistedBeforeInvalidBehavior = sessionStorage.getItem(STORAGE_KEY);
     expect(() => bridge.addWebSocketListener(added.endpoint.endpointId, { preset: "invalid" })).toThrow();
     expect(() => bridge.setWebSocketListenerBehavior(listener.listener.info.id, { preset: "invalid" })).toThrow();
+    expect(() => bridge.addWebSocketListener(added.endpoint.endpointId, { preset: "default" })).toThrow(
+      "Temporary WebSocket listeners require a send or close default action"
+    );
+    expect(() => bridge.setWebSocketListenerBehavior(listener.listener.info.id, { preset: "default" })).toThrow(
+      "Temporary WebSocket listeners require a send or close default action"
+    );
     expect(bridge.getWebSocketEndpoint(added.endpoint.endpointId)?.listeners).toEqual([
       expect.objectContaining({ behavior: { preset: "close", options: { code: 4001 } } }),
     ]);

--- a/packages/core/src/msw/websocket.test.ts
+++ b/packages/core/src/msw/websocket.test.ts
@@ -115,11 +115,11 @@ describe("wrapped ws", () => {
       preset: "close",
       options: { code: 4000, reason: "configured close" },
     });
-    const closed = new Promise<number>((resolve) => {
-      first.addEventListener("close", (event) => resolve(event.code), { once: true });
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      first.addEventListener("close", (event) => resolve({ code: event.code, reason: event.reason }), { once: true });
     });
     first.send("close");
-    expect(await closed).toBe(4000);
+    await expect(closed).resolves.toEqual({ code: 4000, reason: "configured close" });
     store.getState().setWebSocketListenerBehavior(firstListenerId, { preset: "default" });
 
     // A second connection repeats registration order zero and is upserted.

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -225,7 +225,7 @@ describe("snapshot file protocol", () => {
     await removeSnapshotWebSocketListener(sessionPath, firstListener.info.id);
     const replacement = (await addSnapshotWebSocketListener(sessionPath, first.endpointId, { preset: "send", options: { message: "replacement" } }))
       .state.webSocket![0]!.listeners.find((listener) => listener.info.id !== secondListener.info.id)!;
-    expect(replacement.info.id).toBe(`${first.endpointId}:message:2`);
+    expect(replacement.info.id).toBe(`${first.endpointId}:temp:message:2`);
 
     const regexp = await addSnapshotWebSocketEndpoint(sessionPath, {
       kind: "regexp",

--- a/packages/core/src/shared/store/createHandlerStore.test.ts
+++ b/packages/core/src/shared/store/createHandlerStore.test.ts
@@ -9,6 +9,35 @@ afterEach(() => {
 });
 
 describe("createHandlerStore WebSocket coordination", () => {
+  it("keeps a code listener when a temporary listener was added before connection", async () => {
+    const store = createHandlerStore<SetupServer>({
+      createRuntime: (handlers) => setupServer(...handlers),
+    });
+    await store.getState().setupDevToolRuntime();
+    store.getState().registerCodeWebSocketEndpoint({
+      id: "code-endpoint",
+      endpoint: "ws://code.test/chat",
+      source: "code",
+    });
+
+    const tempListenerId = store.getState().addTempWebSocketListener({
+      endpointId: "code-endpoint",
+      behavior: { preset: "send", options: { message: "temp" } },
+    });
+    store.getState().registerCodeWebSocketListener({
+      id: "code-endpoint:message:0",
+      endpointId: "code-endpoint",
+      order: 0,
+      event: "message",
+      source: "code",
+    });
+
+    expect(store.getState().getWebSocketEndpoint("code-endpoint")?.listeners.map((listener) => listener.info.id)).toEqual([
+      tempListenerId,
+      "code-endpoint:message:0",
+    ]);
+  });
+
   it("coordinates temporary lifecycle and direct code registration", async () => {
     const runtime = {
       addTempEndpoint: vi.fn(),

--- a/packages/core/src/shared/store/createHandlerStore.test.ts
+++ b/packages/core/src/shared/store/createHandlerStore.test.ts
@@ -117,7 +117,7 @@ describe("createHandlerStore WebSocket coordination", () => {
     });
     store.getState().addTempWebSocketListener({
       endpointId,
-      behavior: { preset: "default" },
+      behavior: { preset: "send", options: { message: "hydrated" } },
     });
     store.getState().hydrateWebSocket(store.getState().webSocket.endpoints);
 

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -116,15 +116,15 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             : endpoint.listeners;
           listeners.forEach((config) => {
             if (!config?.enabled) return;
-            const behavior = config.behavior;
-            if (behavior.preset === "default") { original?.(event); return; }
-            if (behavior.preset === "send") {
-              const options = webSocketSendOptionsSchema.safeParse(behavior.options);
+            const defaultAction = config.behavior;
+            if (defaultAction.preset === "default") { original?.(event); return; }
+            if (defaultAction.preset === "send") {
+              const options = webSocketSendOptionsSchema.safeParse(defaultAction.options);
               if (options.success) client.send(options.data.message);
               return;
             }
-            if (behavior.preset === "close") {
-              const options = webSocketCloseOptionsSchema.safeParse(behavior.options);
+            if (defaultAction.preset === "close") {
+              const options = webSocketCloseOptionsSchema.safeParse(defaultAction.options);
               if (options.success) client.close(options.data.code, options.data.reason);
             }
           });

--- a/packages/core/src/shared/websocket/state.ts
+++ b/packages/core/src/shared/websocket/state.ts
@@ -19,6 +19,11 @@ export const createWebSocketEndpointId = (matcher: SerializableWebSocketMatcher)
 export const createWebSocketListenerId = (endpointId: string, index: number) =>
   `${endpointId}:message:${index}`;
 
+/** Temporary listeners use a separate namespace so they never collide with
+ * listeners discovered from code when a connection is established later. */
+export const createTemporaryWebSocketListenerId = (endpointId: string, index: number) =>
+  `${endpointId}:temp:message:${index}`;
+
 export const webSocketEndpointFromMatcher = (matcher: SerializableWebSocketMatcher): string =>
   matcher.kind === "string" ? matcher.value : `/${matcher.source}/${matcher.flags}`;
 
@@ -90,11 +95,11 @@ export const addTemporaryWebSocketListener = (
   const endpoint = findEndpoint(endpoints, endpointId);
   const behavior = behaviorInput;
   let index = endpoint.listeners.length;
-  let listenerId = createWebSocketListenerId(endpointId, index);
+  let listenerId = createTemporaryWebSocketListenerId(endpointId, index);
   const listeners = endpoints.flatMap((entry) => entry.listeners);
   while (listeners.some((listener) => listener.info.id === listenerId)) {
     index += 1;
-    listenerId = createWebSocketListenerId(endpointId, index);
+    listenerId = createTemporaryWebSocketListenerId(endpointId, index);
   }
   const listener: WebSocketListenerConfig = {
     info: { id: listenerId, kind: "websocket", endpoint: endpoint.info.endpoint, operation: "message", source: "temp" },

--- a/packages/core/src/shared/websocket/state.ts
+++ b/packages/core/src/shared/websocket/state.ts
@@ -94,6 +94,9 @@ export const addTemporaryWebSocketListener = (
 ) => {
   const endpoint = findEndpoint(endpoints, endpointId);
   const behavior = behaviorInput;
+  if (behavior.preset === "default") {
+    throw new Error("Temporary WebSocket listeners require a send or close default action");
+  }
   let index = endpoint.listeners.length;
   let listenerId = createTemporaryWebSocketListenerId(endpointId, index);
   const listeners = endpoints.flatMap((entry) => entry.listeners);
@@ -152,8 +155,11 @@ export const setWebSocketListenerBehavior = (
   listenerId: string,
   behaviorInput: WebSocketBehaviorSelection
 ) => {
-  findListener(endpoints, listenerId);
+  const { listener: currentListener } = findListener(endpoints, listenerId);
   const behavior = behaviorInput;
+  if (currentListener.info.source === "temp" && behavior.preset === "default") {
+    throw new Error("Temporary WebSocket listeners require a send or close default action");
+  }
   const nextEndpoints = endpoints.map((endpoint) => ({
     ...endpoint,
     listeners: endpoint.listeners.map((entry) =>

--- a/packages/example/src/components/BrowserWebSocketProbe.tsx
+++ b/packages/example/src/components/BrowserWebSocketProbe.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-const ENDPOINT = "ws://browser.example.local/cli-e2e";
+const ENDPOINT = "ws://browser.example.local/chat";
 
 type Result = "idle" | "connecting" | `message: ${string}` | `close: ${number} ${string}` | "timeout" | "error";
 

--- a/packages/example/src/mocks/handlers.ts
+++ b/packages/example/src/mocks/handlers.ts
@@ -1,8 +1,11 @@
 import { http, HttpResponse, RequestHandler, WebSocketHandler } from "msw";
+import { ws } from "@msw-dev-tool/core/msw";
 import { users } from "./data";
 
 /** Absolute URL used by RSC so SSR fetch does not hit the Next server itself. */
 export const SSR_USERS_URL = "https://ssr.example.local/users";
+
+const browserChat = ws.link("ws://browser.example.local/chat");
 
 export const handlers: Array<RequestHandler | WebSocketHandler> = [
   // Node's fetch requires an absolute URL, unlike browser fetch.
@@ -21,5 +24,10 @@ export const handlers: Array<RequestHandler | WebSocketHandler> = [
   }),
   http.get(SSR_USERS_URL, () => {
     return HttpResponse.json(users, { status: 200 });
+  }),
+  browserChat.addEventListener("connection", ({ client }) => {
+    client.addEventListener("message", (event) => {
+      client.send(`echo:${String(event.data)}`);
+    });
   }),
 ];

--- a/packages/react/src/style/msw-dev-tool.css
+++ b/packages/react/src/style/msw-dev-tool.css
@@ -391,6 +391,36 @@
   font-size: 0.875rem;
 }
 
+/* ===== WebSocket panel ===== */
+.msw-dt-tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid #d1d5db; margin-top: 1rem; }
+.msw-dt-tabs .msw-dt-btn { color: #111827; }
+.msw-dt-tab-active { border-bottom: 2px solid #111827; border-radius: 0; }
+.msw-dt-ws-panel { padding-top: 0.25rem; }
+.msw-dt-ws-intro { margin: 0; color: #6b7280; font-size: 0.875rem; }
+.msw-dt-ws-dialog-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.msw-dt-ws-empty { color: #6b7280; padding: 2rem 0; text-align: center; }
+.msw-dt-ws-table { margin-top: 1rem; }
+.msw-dt-ws-table th, .msw-dt-ws-table td { padding: 0.5rem; text-align: left; }
+.msw-dt-ws-endpoint-row { cursor: pointer; border-top: 1px solid #e5e7eb; }
+.msw-dt-ws-endpoint-row:hover { background: #f9fafb; }
+.msw-dt-ws-endpoint-info { display: flex; min-width: 0; flex-direction: column; overflow: hidden; }
+.msw-dt-ws-endpoint-info > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.msw-dt-ws-endpoint-trigger { display: block; max-width: 100%; overflow: hidden; padding: 0; color: inherit; font-weight: 600; text-align: left; text-overflow: ellipsis; white-space: nowrap; }
+.msw-dt-ws-meta { display: block; color: #6b7280; font-size: 0.75rem; }
+.msw-dt-ws-detail-row > td { padding: 0; }
+.msw-dt-ws-listeners { border: 1px solid #e5e7eb; border-radius: 0.375rem; background: #fff; padding: 0.75rem 1rem 1rem 2.5rem; }
+.msw-dt-ws-listener-toolbar { display: flex; justify-content: flex-start; margin-bottom: 0.5rem; }
+.msw-dt-ws-listener-table th, .msw-dt-ws-listener-table td { padding: 0.5rem; text-align: left; }
+.msw-dt-ws-behavior-control { display: flex; align-items: center; gap: 0.25rem; }
+.msw-dt-ws-form { display: flex; flex-direction: column; gap: 0.5rem; min-width: min(26rem, 60vw); margin-top: 1rem; }
+.msw-dt-ws-toggle { cursor: pointer; display: inline-flex; }
+.msw-dt-ws-toggle input { position: absolute; opacity: 0; }
+.msw-dt-ws-toggle span { width: 2rem; height: 1.125rem; background: #9ca3af; border-radius: 999px; position: relative; }
+.msw-dt-ws-toggle span::after { content: ""; width: 0.875rem; height: 0.875rem; border-radius: 50%; background: #fff; position: absolute; top: 0.125rem; left: 0.125rem; transition: transform .15s ease; }
+.msw-dt-ws-toggle input:checked + span { background: #0d9488; }
+.msw-dt-ws-toggle input:checked + span::after { transform: translateX(0.875rem); }
+.msw-dt-ws-toggle input:focus-visible + span { outline: 2px solid #f97316; outline-offset: 2px; }
+
 /* ===== Misc ===== */
 .msw-dt-font-bold { font-weight: 700; }
 .msw-dt-font-semibold { font-weight: 600; }

--- a/packages/react/src/ui/DevToolContent/ToolButtonGroup/index.tsx
+++ b/packages/react/src/ui/DevToolContent/ToolButtonGroup/index.tsx
@@ -7,7 +7,13 @@ import { useHandlerStore } from "@msw-dev-tool/core/browser";
 import { Flex } from "../../Components/Flex";
 import { Button } from "../../Components/Button";
 
-export const ToolButtonGroup = () => {
+export const ToolButtonGroup = ({
+  showAddHandler = true,
+  secondaryAction,
+}: {
+  showAddHandler?: boolean;
+  secondaryAction?: React.ReactNode;
+}) => {
   const resetMSWDevTool = useHandlerStore((state) => state.resetMSWDevTool);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -17,7 +23,8 @@ export const ToolButtonGroup = () => {
         <RotateCcw size={16} />
         Reset Dev tool
       </Button>
-      <Dialog.Root open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      {secondaryAction}
+      {showAddHandler && <Dialog.Root open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <Dialog.Trigger render={<Button><Plus size={16} />Add Temp Handler</Button>} />
         <Dialog.Portal>
           <Dialog.Backdrop className="msw-dt-dialog-backdrop" forceRender />
@@ -38,7 +45,7 @@ export const ToolButtonGroup = () => {
             </div>
           </Dialog.Popup>
         </Dialog.Portal>
-      </Dialog.Root>
+      </Dialog.Root>}
     </Flex>
   );
 };

--- a/packages/react/src/ui/DevToolContent/WebSocketPanel/index.tsx
+++ b/packages/react/src/ui/DevToolContent/WebSocketPanel/index.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from "react";
+import { Dialog } from "@base-ui-components/react/dialog";
+import { Plus, Trash2 } from "lucide-react";
+import {
+  SerializableWebSocketMatcher,
+  WebSocketBehaviorSelection,
+  WebSocketEndpointConfig,
+  WebSocketListenerConfig,
+  useHandlerStore,
+} from "@msw-dev-tool/core/browser";
+import { Button } from "../../Components/Button";
+import { CloseButton } from "../../Components/CloseButton";
+import { Input } from "../../Components/Input";
+import { Select } from "../../Components/Select";
+
+type EndpointFormValues = { matcherType: "string" | "regexp"; value: string; flags: string };
+type ListenerFormValues = { preset: "send" | "close"; message: string; code: string; reason: string };
+type FormErrors = Record<string, string | undefined>;
+
+const matcherLabel = (matcher: SerializableWebSocketMatcher) =>
+  matcher.kind === "string" ? matcher.value : `/${matcher.source}/${matcher.flags}`;
+
+const Toggle = ({ checked, label, onChange }: { checked: boolean; label: string; onChange: (checked: boolean) => void }) => (
+  <label className="msw-dt-ws-toggle">
+    <input type="checkbox" checked={checked} onChange={(event) => onChange(event.target.checked)} aria-label={label} />
+    <span aria-hidden="true" />
+  </label>
+);
+
+const EndpointForm = ({ onClose }: { onClose: () => void }) => {
+  const addEndpoint = useHandlerStore((state) => state.addTempWebSocketEndpoint);
+  const [values, setValues] = useState<EndpointFormValues>({ matcherType: "string", value: "", flags: "" });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const matcher = values.matcherType === "string"
+      ? { kind: "string" as const, value: values.value }
+      : { kind: "regexp" as const, source: values.value, flags: values.flags };
+    if (!values.value.trim()) {
+      setErrors({ value: "Matcher is required" });
+      return;
+    }
+    try {
+      if (matcher.kind === "regexp") new RegExp(matcher.source, matcher.flags);
+      addEndpoint({ matcher, endpoint: matcherLabel(matcher) });
+      onClose();
+    } catch {
+      setErrors({ value: "WebSocket regular-expression matcher must be valid" });
+    }
+  };
+  return <form onSubmit={submit} className="msw-dt-ws-form">
+    <label className="msw-dt-label" htmlFor="ws-matcher-type">Matcher type</label>
+    <Select id="ws-matcher-type" label="Matcher type" value={values.matcherType} onValueChange={(value) => setValues({ ...values, matcherType: (value ?? "string") as EndpointFormValues["matcherType"] })} options={[{ label: "String", value: "string" }, { label: "RegExp", value: "regexp" }]} />
+    <label className="msw-dt-label" htmlFor="ws-matcher">{values.matcherType === "regexp" ? "RegExp source" : "URL matcher"}</label>
+    <Input id="ws-matcher" value={values.value} onChange={(event) => setValues({ ...values, value: event.target.value })} aria-invalid={Boolean(errors.value)} required />
+    {errors.value && <p className="msw-dt-error-text">{errors.value}</p>}
+    {values.matcherType === "regexp" && <><label className="msw-dt-label" htmlFor="ws-flags">RegExp flags</label><Input id="ws-flags" value={values.flags} onChange={(event) => setValues({ ...values, flags: event.target.value })} /></>}
+    <Button type="submit"><Plus size={16} />Add endpoint</Button>
+  </form>;
+};
+
+const ListenerForm = ({ endpoint, onClose }: { endpoint: WebSocketEndpointConfig; onClose: () => void }) => {
+  const addListener = useHandlerStore((state) => state.addTempWebSocketListener);
+  const [values, setValues] = useState<ListenerFormValues>({ preset: "send", message: "", code: "", reason: "" });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const defaultAction: WebSocketBehaviorSelection = values.preset === "send"
+      ? { preset: "send", options: { message: values.message } }
+      : { preset: "close", options: { ...(values.code ? { code: Number(values.code) } : {}), ...(values.reason ? { reason: values.reason } : {}) } };
+    if (defaultAction.preset === "send" && !(defaultAction.options as { message: string }).message.trim()) {
+      setErrors({ form: "Message is required for send behavior" });
+      return;
+    }
+    if (defaultAction.preset === "close") {
+      const close = defaultAction.options as { code?: number; reason?: string };
+      if (close.code !== undefined && (Number.isNaN(close.code) || !Number.isInteger(close.code) || (close.code !== 1000 && (close.code < 3000 || close.code > 4999)))) {
+        setErrors({ form: "WebSocket close code must be 1000 or between 3000 and 4999" });
+        return;
+      }
+      if (close.reason !== undefined && new TextEncoder().encode(close.reason).byteLength > 123) {
+        setErrors({ form: "WebSocket close reason must not exceed 123 UTF-8 bytes" });
+        return;
+      }
+    }
+    addListener({ endpointId: endpoint.endpointId, behavior: defaultAction });
+    onClose();
+  };
+  return <form onSubmit={submit} className="msw-dt-ws-form">
+    <label className="msw-dt-label" htmlFor={`ws-action-${endpoint.endpointId}`}>Default action</label>
+    <Select id={`ws-action-${endpoint.endpointId}`} label="Default action" value={values.preset} onValueChange={(value) => setValues({ ...values, preset: (value ?? "send") as ListenerFormValues["preset"] })} options={[{ label: "send(message)", value: "send" }, { label: "close(code/reason)", value: "close" }]} />
+    {values.preset === "send" && <><label className="msw-dt-label" htmlFor="ws-message">Message</label><Input id="ws-message" value={values.message} onChange={(event) => setValues({ ...values, message: event.target.value })} /></>}
+    {values.preset === "close" && <><label className="msw-dt-label" htmlFor="ws-close-code">Close code</label><Input id="ws-close-code" type="number" value={values.code} onChange={(event) => setValues({ ...values, code: event.target.value })} /><label className="msw-dt-label" htmlFor="ws-close-reason">Close reason</label><Input id="ws-close-reason" value={values.reason} onChange={(event) => setValues({ ...values, reason: event.target.value })} /></>}
+    {errors.form && <p className="msw-dt-error-text">{errors.form}</p>}
+    <Button type="submit">Add listener</Button>
+  </form>;
+};
+
+const ListenerDialog = ({ endpoint }: { endpoint: WebSocketEndpointConfig }) => {
+  const [open, setOpen] = useState(false);
+  return <Dialog.Root open={open} onOpenChange={setOpen}><Dialog.Trigger render={<Button title="Add message listener"><Plus size={16} />Add listener</Button>} /><Dialog.Portal><Dialog.Backdrop className="msw-dt-dialog-backdrop" forceRender /><Dialog.Popup className="msw-dt-dialog-popup-viewport"><div className="msw-dt-dialog-inner-center"><div className="msw-dt-ws-dialog-header"><Dialog.Title className="msw-dt-dialog-title-sm">Add WebSocket listener</Dialog.Title><Dialog.Close render={<CloseButton />} /></div><ListenerForm endpoint={endpoint} onClose={() => setOpen(false)} /></div></Dialog.Popup></Dialog.Portal></Dialog.Root>;
+};
+
+const ListenerBehaviorSelect = ({ listener }: { listener: WebSocketListenerConfig }) => {
+  const setEnabled = useHandlerStore((state) => state.setWebSocketListenerEnabled);
+
+  return <Select
+    label={`Behavior for ${listener.info.id}`}
+    value={listener.enabled ? "default" : "disable"}
+    options={[{ label: "Default", value: "default" }, { label: "Disable mock", value: "disable" }]}
+    className="msw-dt-w-behavior-select"
+    onValueChange={(value) => {
+      if (!value) return;
+      setEnabled(listener.info.id, value !== "disable");
+    }}
+  />;
+};
+
+const EndpointRow = ({ endpoint }: { endpoint: WebSocketEndpointConfig }) => {
+  const [expanded, setExpanded] = useState(false);
+  const removeEndpoint = useHandlerStore((state) => state.removeWebSocketEndpoint);
+  const removeListener = useHandlerStore((state) => state.removeWebSocketListener);
+  const setEndpointEnabled = useHandlerStore((state) => state.setWebSocketEndpointEnabled);
+  const isTemp = endpoint.info.source === "temp";
+  return <>
+    <tr className="msw-dt-ws-endpoint-row">
+      <td><Button variant="ghost" className="msw-dt-ws-endpoint-trigger" aria-expanded={expanded} onClick={() => setExpanded(!expanded)}>{matcherLabel(endpoint.matcher)}</Button></td>
+      <td>{endpoint.listeners.length}</td>
+      <td><Toggle checked={endpoint.enabled} label={`Enable mock for ${matcherLabel(endpoint.matcher)}`} onChange={(enabled) => setEndpointEnabled(endpoint.endpointId, enabled)} /></td>
+      <td><Button variant="ghost" color="danger" disabled={!isTemp} title={isTemp ? "Delete endpoint" : "Endpoints generated from codebase cannot be deleted"} aria-label={isTemp ? `Delete endpoint ${matcherLabel(endpoint.matcher)}` : "Endpoints generated from codebase cannot be deleted"} className={isTemp ? "msw-dt-danger-text" : "msw-dt-disabled-text"} onClick={() => removeEndpoint(endpoint.endpointId)}><Trash2 size={16} /></Button></td>
+    </tr>
+    {expanded && <tr className="msw-dt-ws-detail-row"><td colSpan={4}><div className="msw-dt-ws-listeners">
+      <div className="msw-dt-ws-listener-toolbar"><ListenerDialog endpoint={endpoint} /></div>
+      <table className="msw-dt-table msw-dt-ws-listener-table"><thead><tr><th>Listener</th><th>Behavior</th><th>Delete</th></tr></thead><tbody>
+      {endpoint.listeners.map((listener) => { const listenerIsTemp = listener.info.source === "temp"; return <tr key={listener.info.id}><td>message</td><td><div className="msw-dt-ws-behavior-control"><ListenerBehaviorSelect listener={listener} /></div></td><td><Button variant="ghost" color="danger" disabled={!listenerIsTemp} title={listenerIsTemp ? "Delete listener" : "Listeners generated from codebase cannot be deleted"} aria-label={listenerIsTemp ? `Delete listener ${listener.info.id}` : "Listeners generated from codebase cannot be deleted"} className={listenerIsTemp ? "msw-dt-danger-text" : "msw-dt-disabled-text"} onClick={() => removeListener(listener.info.id)}><Trash2 size={16} /></Button></td></tr>; })}
+      </tbody></table>
+    </div></td></tr>}
+  </>;
+};
+
+export const AddWebSocketEndpointDialog = () => {
+  const [open, setOpen] = useState(false);
+  return <Dialog.Root open={open} onOpenChange={setOpen}><Dialog.Trigger render={<Button><Plus size={16} />Add WebSocket Endpoint</Button>} /><Dialog.Portal><Dialog.Backdrop className="msw-dt-dialog-backdrop" forceRender /><Dialog.Popup className="msw-dt-dialog-popup-viewport"><div className="msw-dt-dialog-inner-center"><div className="msw-dt-ws-dialog-header"><Dialog.Title className="msw-dt-dialog-title-sm">Add WebSocket Endpoint</Dialog.Title><Dialog.Close render={<CloseButton />} /></div><EndpointForm onClose={() => setOpen(false)} /></div></Dialog.Popup></Dialog.Portal></Dialog.Root>;
+};
+
+export const WebSocketPanel = () => {
+  const endpoints = useHandlerStore((state) => state.webSocket.endpoints);
+  return <div className="msw-dt-ws-panel"><p className="msw-dt-ws-intro">Connect to an endpoint to discover its listeners, then click a row to control them.</p>{endpoints.length === 0 ? <p className="msw-dt-ws-empty">No WebSocket endpoints</p> : <table className="msw-dt-table msw-dt-ws-table"><thead><tr><th>API</th><th>Listeners</th><th>Mock Enable</th><th>Delete</th></tr></thead><tbody>{endpoints.map((endpoint) => <EndpointRow key={endpoint.endpointId} endpoint={endpoint} />)}</tbody></table>}</div>;
+};

--- a/packages/react/src/ui/MSWDevTool.tsx
+++ b/packages/react/src/ui/MSWDevTool.tsx
@@ -1,10 +1,12 @@
-import React, { useId } from "react";
+import React, { useId, useState } from "react";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { HandlerTable } from "./DevToolContent/HandlerTable";
 import { ToolButtonGroup } from "./DevToolContent/ToolButtonGroup";
 import { DefaultDevToolTrigger } from "./Trigger";
 import { CloseButton } from "./Components/CloseButton";
 import { Flex } from "./Components/Flex";
+import { Button } from "./Components/Button";
+import { AddWebSocketEndpointDialog, WebSocketPanel } from "./DevToolContent/WebSocketPanel";
 
 interface MSWDevToolProps {
   trigger?: React.ReactElement<
@@ -15,6 +17,7 @@ interface MSWDevToolProps {
 
 export const MSWDevTool = ({ trigger }: MSWDevToolProps) => {
   const titleId = useId();
+  const [tab, setTab] = useState<"http" | "websocket">("http");
 
   return (
     <Dialog.Root>
@@ -36,8 +39,12 @@ export const MSWDevTool = ({ trigger }: MSWDevToolProps) => {
               </Dialog.Title>
               <Dialog.Close render={<CloseButton />} />
             </Flex>
-            <ToolButtonGroup />
-            <HandlerTable />
+            <div className="msw-dt-tabs" role="tablist" aria-label="Mock handlers">
+              <Button variant="ghost" role="tab" aria-selected={tab === "http"} className={tab === "http" ? "msw-dt-tab-active" : ""} onClick={() => setTab("http")}>HTTP</Button>
+              <Button variant="ghost" role="tab" aria-selected={tab === "websocket"} className={tab === "websocket" ? "msw-dt-tab-active" : ""} onClick={() => setTab("websocket")}>WebSocket</Button>
+            </div>
+            <ToolButtonGroup showAddHandler={tab === "http"} secondaryAction={tab === "websocket" ? <AddWebSocketEndpointDialog /> : undefined} />
+            {tab === "http" ? <HandlerTable /> : <WebSocketPanel />}
           </div>
         </Dialog.Popup>
       </Dialog.Portal>


### PR DESCRIPTION
## Summary
close #162
- Add an endpoint-and-listener control surface for WebSocket mocks in the React dev tool.
- Keep code-derived listeners and temporary listeners as distinct state layers, with explicit default-action semantics.
- Expose the WebSocket flow through the browser example and publish the associated package changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a WebSocket management panel with endpoint and listener controls.
  * Supports creating temporary endpoints and listeners with send or close actions.
  * Added HTTP and WebSocket tabs in the developer tool.
  * Added validation for endpoint matchers, messages, close codes, and reasons.
  * Added an example chat WebSocket with echoed messages.

* **Bug Fixes**
  * Prevented invalid default actions for temporary WebSocket listeners.
  * Preserved code-based listeners when temporary listeners are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->