### PR TITLE
feat: add WebSocket response presets

### DIFF
--- a/.changeset/tidy-wombats-echo.md
+++ b/.changeset/tidy-wombats-echo.md
@@ -1,0 +1,6 @@
+---
+"@msw-dev-tool/core": patch
+"@msw-dev-tool/react": patch
+---
+
+Add configurable WebSocket response presets and listener controls.

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -138,10 +138,10 @@ describe("browser control bridge", () => {
     expect(() => bridge.addWebSocketListener(added.endpoint.endpointId, { preset: "invalid" })).toThrow();
     expect(() => bridge.setWebSocketListenerBehavior(listener.listener.info.id, { preset: "invalid" })).toThrow();
     expect(() => bridge.addWebSocketListener(added.endpoint.endpointId, { preset: "default" })).toThrow(
-      "Temporary WebSocket listeners require a send or close default action"
+      "Temporary WebSocket listeners require a response behavior"
     );
     expect(() => bridge.setWebSocketListenerBehavior(listener.listener.info.id, { preset: "default" })).toThrow(
-      "Temporary WebSocket listeners require a send or close default action"
+      "Temporary WebSocket listeners require a response behavior"
     );
     expect(bridge.getWebSocketEndpoint(added.endpoint.endpointId)?.listeners).toEqual([
       expect.objectContaining({ behavior: { preset: "close", options: { code: 4001 } } }),

--- a/packages/core/src/msw/websocket.runtime.test.ts
+++ b/packages/core/src/msw/websocket.runtime.test.ts
@@ -204,4 +204,39 @@ describe("closeWebSocketConnections", () => {
       vi.useRealTimers();
     }
   });
+
+  it("cancels scheduled sequence messages during a Dev Tool reset", async () => {
+    vi.useFakeTimers();
+    try {
+      const endpoint = ws.link("ws://wrapper.test/reset-sequence");
+      const handler = endpoint.addEventListener("connection", () => undefined);
+      const store = createHandlerStore<SetupServer>({
+        createRuntime: (handlers) => setupServer(...handlers),
+      });
+      await store.getState().setupDevToolRuntime(handler);
+      const hook = Reflect.get(handler, WEBSOCKET_HANDLER_BIND) as { getAdapter(): WebSocketStoreAdapter | undefined };
+      const adapter = hook.getAdapter()!;
+      const endpointId = store.getState().webSocket.endpoints[0]!.endpointId;
+      const listenerId = `${endpointId}:message:0`;
+      store.getState().registerCodeWebSocketListener({
+        id: listenerId,
+        endpointId,
+        order: 0,
+        event: "message",
+        source: "code",
+      });
+      store.getState().setWebSocketListenerBehavior(listenerId, { preset: "send-sequence" });
+      const client = { send: vi.fn(), close: vi.fn() };
+      adapter.registerWebSocketConnection(endpointId, client);
+      adapter.dispatchWebSocketMessage(endpointId, client, new Event("message"), listenerId);
+      expect(client.send).toHaveBeenCalledTimes(1);
+
+      adapter.resetWebSocketConnections();
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/core/src/msw/websocket.runtime.test.ts
+++ b/packages/core/src/msw/websocket.runtime.test.ts
@@ -59,7 +59,7 @@ describe("temporary WebSocket runtime", () => {
       endpoint: "ws://wrapper.test/temp-runtime",
       matcher: { kind: "string", value: "ws://wrapper.test/temp-runtime" },
     });
-    store.getState().addTempWebSocketListener({
+    const listenerId = store.getState().addTempWebSocketListener({
       endpointId,
       behavior: { preset: "send", options: { message: "temp-reply" } },
     });
@@ -81,11 +81,41 @@ describe("temporary WebSocket runtime", () => {
     const reply = nextMessage(socket);
     socket.send("ping");
     expect(await reply).toBe("temp-reply");
+
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "echo" });
+    const echoed = nextMessage(socket);
+    socket.send("echo this");
+    expect(await echoed).toBe("echo this");
+
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "send-null" });
+    const nullMessage = nextMessage(socket);
+    socket.send("null please");
+    expect(await nullMessage).toBe("null");
+
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "no-reply" });
+    let replied = false;
+    socket.addEventListener("message", () => { replied = true; }, { once: true });
+    socket.send("wait");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(replied).toBe(false);
+    expect(socket.readyState).toBe(WebSocket.OPEN);
+
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "send-sequence" });
+    const messages: string[] = [];
+    const completed = new Promise<void>((resolve) => {
+      socket.addEventListener("message", (event) => {
+        messages.push(String(event.data));
+        if (messages.length === 3) resolve();
+      });
+    });
+    socket.send("start");
+    await completed;
+    expect(messages).toEqual(["Test message from MSW Dev Tool", "Test message from MSW Dev Tool", "Test message from MSW Dev Tool"]);
     socket.close();
     await waitFor(() => socket.readyState === WebSocket.CLOSED);
 
     store.getState().setWebSocketListenerBehavior(
-      store.getState().webSocket.listeners[0]!.info.id,
+      listenerId,
       { preset: "close", options: { code: 4001, reason: "temp-close" } },
     );
     const closing = await openSocket("ws://wrapper.test/temp-runtime");
@@ -137,5 +167,41 @@ describe("closeWebSocketConnections", () => {
 
     adapter.closeWebSocketConnections(endpointId);
     expect(fakeClose).toHaveBeenCalledOnce();
+  });
+
+  it("cancels scheduled sequence messages before closing connections", async () => {
+    vi.useFakeTimers();
+    try {
+      const endpoint = ws.link("ws://wrapper.test/cancel-sequence");
+      const handler = endpoint.addEventListener("connection", () => undefined);
+      const store = createHandlerStore<SetupServer>({
+        createRuntime: (handlers) => setupServer(...handlers),
+      });
+      await store.getState().setupDevToolRuntime(handler);
+      const hook = Reflect.get(handler, WEBSOCKET_HANDLER_BIND) as { getAdapter(): WebSocketStoreAdapter | undefined };
+      const adapter = hook.getAdapter()!;
+      const endpointId = store.getState().webSocket.endpoints[0]!.endpointId;
+      const listenerId = `${endpointId}:message:0`;
+      store.getState().registerCodeWebSocketListener({
+        id: listenerId,
+        endpointId,
+        order: 0,
+        event: "message",
+        source: "code",
+      });
+      store.getState().setWebSocketListenerBehavior(listenerId, { preset: "send-sequence" });
+      const client = { send: vi.fn(), close: vi.fn() };
+      adapter.registerWebSocketConnection(endpointId, client);
+      adapter.dispatchWebSocketMessage(endpointId, client, new Event("message"), listenerId);
+      expect(client.send).toHaveBeenCalledTimes(1);
+
+      adapter.closeWebSocketConnections(endpointId);
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(client.close).toHaveBeenCalledOnce();
+      expect(client.send).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/src/shared/schema/websocket.test.ts
+++ b/packages/core/src/shared/schema/websocket.test.ts
@@ -82,4 +82,18 @@ describe("websocket schema", () => {
       options: { reason: "€".repeat(41) + "a" },
     })).toThrow("WebSocket close reason must not exceed 123 UTF-8 bytes");
   });
+
+  it("accepts the built-in response presets", () => {
+    for (const behavior of [
+      { preset: "echo" },
+      { preset: "send-null" },
+      { preset: "no-reply" },
+      { preset: "send-sequence" },
+    ]) {
+      expect(() => webSocketBehaviorSchema.parse(behavior)).not.toThrow();
+    }
+    for (const code of [1000, 4000, 4001, 4008]) {
+      expect(() => webSocketBehaviorSchema.parse({ preset: "close", options: { code } })).not.toThrow();
+    }
+  });
 });

--- a/packages/core/src/shared/schema/websocket.ts
+++ b/packages/core/src/shared/schema/websocket.ts
@@ -17,6 +17,10 @@ export const webSocketBehaviorSchema = z.union([
   z.object({ preset: z.literal("default") }).strict(),
   z.object({ preset: z.literal("send"), options: webSocketSendOptionsSchema }).strict(),
   z.object({ preset: z.literal("close"), options: webSocketCloseOptionsSchema.optional() }).strict(),
+  z.object({ preset: z.literal("echo") }).strict(),
+  z.object({ preset: z.literal("send-null") }).strict(),
+  z.object({ preset: z.literal("no-reply") }).strict(),
+  z.object({ preset: z.literal("send-sequence") }).strict(),
 ]);
 export const serializableWebSocketMatcherSchema = z.union([
   z.object({ kind: z.literal("string"), value: z.string() }),

--- a/packages/core/src/shared/store/createHandlerStore.test.ts
+++ b/packages/core/src/shared/store/createHandlerStore.test.ts
@@ -74,7 +74,7 @@ describe("createHandlerStore WebSocket coordination", () => {
     });
     const listenerId = store.getState().addTempWebSocketListener({
       endpointId,
-      behavior: { preset: "reply" },
+      behavior: { preset: "echo" },
     });
     expect(store.getState().getWebSocketListener(listenerId)).toMatchObject({
       endpointId,
@@ -82,7 +82,7 @@ describe("createHandlerStore WebSocket coordination", () => {
     store.getState().setWebSocketEndpointEnabled(endpointId, true);
     store.getState().setWebSocketEndpointEnabled(endpointId, false);
     store.getState().setWebSocketListenerEnabled(listenerId, false);
-    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "drop" });
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "no-reply" });
     store.getState().removeWebSocketListener(listenerId);
     store.getState().removeWebSocketEndpoint(endpointId);
     store.getState().resetMSWDevTool();

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -14,8 +14,9 @@ import {
   FlattenHandler,
   Handler,
 } from "../types";
+import type { WebSocketData } from "msw";
 import { deleteEmptySet, initMSWDevToolStore } from "../utils";
-import { bindWebSocketHandler, type WebSocketMessageListenerRegistration } from "../websocket/bind";
+import { bindWebSocketHandler, type ManagedWebSocketClient, type WebSocketMessageListenerRegistration } from "../websocket/bind";
 import { createTemporaryWebSocketHandler } from "../../msw/websocket";
 import { webSocketEndpointsSchema } from "../schema/websocket";
 import { webSocketCloseOptionsSchema, webSocketSendOptionsSchema } from "../schema/websocket";
@@ -39,6 +40,9 @@ export type {
   MswDevToolRuntime,
 } from "./types";
 
+const isWebSocketMessageEvent = (event: Event): event is MessageEvent<WebSocketData> =>
+  "data" in event;
+
 const registerTempHandlers = (
   runtime: MswDevToolRuntime,
   flattenHandlers: FlattenHandler[]
@@ -57,16 +61,27 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
   const store = createStore<HandlerStoreInternalState<TRuntime>>(
     (set, get) => {
       const registry = createHandlerRegistry();
-      const connections = new Map<string, Set<{ close: (code?: number, reason?: string) => void }>>();
+      const connections = new Map<string, Set<ManagedWebSocketClient>>();
       const reconnectors = new Map<string, Set<WebSocketMessageListenerRegistration>>();
+      const sequenceTimers = new WeakMap<object, Set<ReturnType<typeof setTimeout>>>();
+      const clearSequenceTimers = (client: object) => {
+        sequenceTimers.get(client)?.forEach((timer) => clearTimeout(timer));
+        sequenceTimers.delete(client);
+      };
+      const closeConnections = (id: string) => {
+        connections.get(id)?.forEach((client) => {
+          clearSequenceTimers(client);
+          client.close();
+        });
+        connections.delete(id);
+        reconnectors.delete(id);
+      };
       const temporaryHandlers = new Map<string, unknown>();
       let codeWebSocketHandlers: readonly Handler[] = [];
       const webSocketSlice = createWebSocketSlice({
         ...options.webSocketRuntime,
         closeEndpointConnections: (id) => {
-          connections.get(id)?.forEach((client) => client.close());
-          connections.delete(id);
-          reconnectors.delete(id);
+          closeConnections(id);
           options.webSocketRuntime?.closeEndpointConnections?.(id);
         },
       });
@@ -85,12 +100,13 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
         },
         getWebSocketEndpoint: (id: string) => webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === id),
         getWebSocketListener: (id: string) => webSocketSlice.getState().listeners.find((entry) => entry.info.id === id),
-        registerWebSocketConnection: (id: string, client: { close: (code?: number, reason?: string) => void }) => {
+        registerWebSocketConnection: (id: string, client: ManagedWebSocketClient) => {
           let set = connections.get(id);
           if (!set) { set = new Set(); connections.set(id, set); }
           set.add(client);
         },
-        unregisterWebSocketConnection: (id: string, client: { close: (code?: number, reason?: string) => void }) => {
+        unregisterWebSocketConnection: (id: string, client: ManagedWebSocketClient) => {
+          clearSequenceTimers(client);
           const set = connections.get(id);
           if (!set) return;
           set.delete(client);
@@ -108,7 +124,7 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           deleteEmptySet(reconnectors, id, set);
         },
         connectWebSocket: (_id: string, server: { connect: () => void }) => server.connect(),
-        dispatchWebSocketMessage: (endpointId: string, client: { send: (data: string) => void; close: (code?: number, reason?: string) => void }, event: Event, listenerId?: string, original?: (event: Event) => void) => {
+        dispatchWebSocketMessage: (endpointId: string, client: ManagedWebSocketClient, event: Event, listenerId?: string, original?: (event: Event) => void) => {
           const endpoint = webSocketSlice.getState().endpoints.find((entry) => entry.endpointId === endpointId);
           if (!endpoint?.enabled) return;
           const listeners = listenerId
@@ -126,13 +142,36 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             if (defaultAction.preset === "close") {
               const options = webSocketCloseOptionsSchema.safeParse(defaultAction.options);
               if (options.success) client.close(options.data.code, options.data.reason);
+              return;
+            }
+            if (defaultAction.preset === "echo") {
+              if (isWebSocketMessageEvent(event)) client.send(event.data);
+              return;
+            }
+            if (defaultAction.preset === "send-null") {
+              client.send("null");
+              return;
+            }
+            if (defaultAction.preset === "no-reply") {
+              return;
+            }
+            if (defaultAction.preset === "send-sequence") {
+              const message = "Test message from MSW Dev Tool";
+              client.send(message);
+              const timers = sequenceTimers.get(client) ?? new Set<ReturnType<typeof setTimeout>>();
+              sequenceTimers.set(client, timers);
+              [1_000, 2_000].forEach((delay) => {
+                const timer = setTimeout(() => {
+                  timers.delete(timer);
+                  client.send(message);
+                }, delay);
+                timers.add(timer);
+              });
             }
           });
         },
         closeWebSocketConnections: (id: string) => {
-          connections.get(id)?.forEach((client) => client.close());
-          connections.delete(id);
-          reconnectors.delete(id);
+          closeConnections(id);
         },
         resetWebSocketConnections: () => {
           reconnectors.forEach((listeners) => listeners.forEach(({ disconnect, reconnect }) => {

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -174,6 +174,7 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
           closeConnections(id);
         },
         resetWebSocketConnections: () => {
+          connections.forEach((clients) => clients.forEach(clearSequenceTimers));
           reconnectors.forEach((listeners) => listeners.forEach(({ disconnect, reconnect }) => {
             disconnect?.();
             reconnect();

--- a/packages/core/src/shared/types/websocket.ts
+++ b/packages/core/src/shared/types/websocket.ts
@@ -29,10 +29,14 @@ export type DevToolHandlerInfo = {
   source: "code" | "temp";
 };
 
-export type WebSocketBehaviorSelection = {
-  preset: string;
-  options?: unknown;
-};
+export type WebSocketBehaviorSelection =
+  | { preset: "default" }
+  | { preset: "send"; options: { message: string } }
+  | { preset: "close"; options?: { code?: number; reason?: string } }
+  | { preset: "echo" }
+  | { preset: "send-null" }
+  | { preset: "no-reply" }
+  | { preset: "send-sequence" };
 
 export type WebSocketHandlerInfo = Omit<DevToolHandlerInfo, "kind"> & { kind: "websocket" };
 

--- a/packages/core/src/shared/websocket/bind.ts
+++ b/packages/core/src/shared/websocket/bind.ts
@@ -5,6 +5,12 @@ import type {
   ManagedWebSocketListener,
 } from "../types/websocket";
 import type { WebSocketEndpointConfig, WebSocketListenerConfig } from "../types/websocket";
+import type { WebSocketData } from "msw";
+
+export type ManagedWebSocketClient = {
+  send: (data: WebSocketData) => void;
+  close: (code?: number, reason?: string) => void;
+};
 
 export const WEBSOCKET_HANDLER_BIND = Symbol.for(
   "@msw-dev-tool/core/websocket-handler-bind/v1"
@@ -20,12 +26,12 @@ export type WebSocketStoreAdapter = {
   registerCodeWebSocketListener(listener: ManagedWebSocketListener): void;
   getWebSocketEndpoint(endpointId: string): WebSocketEndpointConfig | undefined;
   getWebSocketListener(listenerId: string): WebSocketListenerConfig | undefined;
-  registerWebSocketConnection(endpointId: string, client: { close: (code?: number, reason?: string) => void }): void;
-  unregisterWebSocketConnection(endpointId: string, client: { close: (code?: number, reason?: string) => void }): void;
+  registerWebSocketConnection(endpointId: string, client: ManagedWebSocketClient): void;
+  unregisterWebSocketConnection(endpointId: string, client: ManagedWebSocketClient): void;
   registerWebSocketMessageListener(endpointId: string, registration: WebSocketMessageListenerRegistration): void;
   unregisterWebSocketMessageListener(endpointId: string, registration: WebSocketMessageListenerRegistration): void;
   connectWebSocket(endpointId: string, server: { connect: () => void }): void;
-  dispatchWebSocketMessage(endpointId: string, client: { send: (data: string) => void; close: (code?: number, reason?: string) => void }, event: Event, listenerId?: string, original?: (event: Event) => void): void;
+  dispatchWebSocketMessage(endpointId: string, client: ManagedWebSocketClient, event: Event, listenerId?: string, original?: (event: Event) => void): void;
   closeWebSocketConnections(endpointId: string): void;
   resetWebSocketConnections(): void;
 };

--- a/packages/core/src/shared/websocket/state.ts
+++ b/packages/core/src/shared/websocket/state.ts
@@ -95,7 +95,7 @@ export const addTemporaryWebSocketListener = (
   const endpoint = findEndpoint(endpoints, endpointId);
   const behavior = behaviorInput;
   if (behavior.preset === "default") {
-    throw new Error("Temporary WebSocket listeners require a send or close default action");
+    throw new Error("Temporary WebSocket listeners require a response behavior");
   }
   let index = endpoint.listeners.length;
   let listenerId = createTemporaryWebSocketListenerId(endpointId, index);
@@ -158,7 +158,7 @@ export const setWebSocketListenerBehavior = (
   const { listener: currentListener } = findListener(endpoints, listenerId);
   const behavior = behaviorInput;
   if (currentListener.info.source === "temp" && behavior.preset === "default") {
-    throw new Error("Temporary WebSocket listeners require a send or close default action");
+    throw new Error("Temporary WebSocket listeners require a response behavior");
   }
   const nextEndpoints = endpoints.map((endpoint) => ({
     ...endpoint,

--- a/packages/react/src/ui/DevToolContent/WebSocketPanel/index.tsx
+++ b/packages/react/src/ui/DevToolContent/WebSocketPanel/index.tsx
@@ -14,14 +14,43 @@ import { Input } from "../../Components/Input";
 import { Select } from "../../Components/Select";
 
 type EndpointFormValues = { matcherType: "string" | "regexp"; value: string; flags: string };
-type ListenerFormValues = { preset: "send" | "close"; message: string; code: string; reason: string };
 type FormErrors = Record<string, string | undefined>;
+
+const TEST_MESSAGE = "Test message from MSW Dev Tool";
+
+const behaviorOptions = [
+  { label: "Default", value: "default", behavior: { preset: "default" } },
+  { label: "No reply (delay)", value: "no-reply", behavior: { preset: "no-reply" } },
+  { label: "Send null", value: "send-null", behavior: { preset: "send-null" } },
+  { label: "Close (4000 — Error)", value: "close-4000", behavior: { preset: "close", options: { code: 4000, reason: "Error" } } },
+  { label: "Send test message", value: "send", behavior: { preset: "send", options: { message: TEST_MESSAGE } } },
+  { label: "Echo message", value: "echo", behavior: { preset: "echo" } },
+  { label: "Repeat message (3 times, every 1 sec)", value: "send-sequence", behavior: { preset: "send-sequence" } },
+  { label: "Close (1000 — Normal)", value: "close-1000", behavior: { preset: "close", options: { code: 1000, reason: "Normal closure" } } },
+  { label: "Close (4001 — Unauthorized)", value: "close-4001", behavior: { preset: "close", options: { code: 4001, reason: "Unauthorized" } } },
+  { label: "Close (4008 — Rate limited)", value: "close-4008", behavior: { preset: "close", options: { code: 4008, reason: "Rate limited" } } },
+] as const satisfies ReadonlyArray<{ label: string; value: string; behavior: WebSocketBehaviorSelection }>;
+
+const closeBehaviorValue = (code?: number) => `close-${code ?? 1000}`;
+
+const behaviorValue = (behavior: WebSocketBehaviorSelection) =>
+  behavior.preset === "close"
+    ? closeBehaviorValue((behavior.options as { code?: number } | undefined)?.code)
+    : behavior.preset;
+
+const behaviorLabel = (behavior: WebSocketBehaviorSelection) =>
+  behavior.preset === "close"
+    ? `Close (${(behavior.options as { code?: number } | undefined)?.code ?? 1000})`
+    : behavior.preset;
+
+const selectableBehaviorOptions = (source: WebSocketListenerConfig["info"]["source"]) =>
+  behaviorOptions.filter((option) => source === "code" || option.value !== "default");
 
 const matcherLabel = (matcher: SerializableWebSocketMatcher) =>
   matcher.kind === "string" ? matcher.value : `/${matcher.source}/${matcher.flags}`;
 
 const Toggle = ({ checked, label, onChange }: { checked: boolean; label: string; onChange: (checked: boolean) => void }) => (
-  <label className="msw-dt-ws-toggle">
+  <label className="msw-dt-ws-toggle" onClick={(event) => event.stopPropagation()}>
     <input type="checkbox" checked={checked} onChange={(event) => onChange(event.target.checked)} aria-label={label} />
     <span aria-hidden="true" />
   </label>
@@ -61,37 +90,17 @@ const EndpointForm = ({ onClose }: { onClose: () => void }) => {
 
 const ListenerForm = ({ endpoint, onClose }: { endpoint: WebSocketEndpointConfig; onClose: () => void }) => {
   const addListener = useHandlerStore((state) => state.addTempWebSocketListener);
-  const [values, setValues] = useState<ListenerFormValues>({ preset: "send", message: "", code: "", reason: "" });
-  const [errors, setErrors] = useState<FormErrors>({});
+  const [preset, setPreset] = useState("send");
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
-    const defaultAction: WebSocketBehaviorSelection = values.preset === "send"
-      ? { preset: "send", options: { message: values.message } }
-      : { preset: "close", options: { ...(values.code ? { code: Number(values.code) } : {}), ...(values.reason ? { reason: values.reason } : {}) } };
-    if (defaultAction.preset === "send" && !(defaultAction.options as { message: string }).message.trim()) {
-      setErrors({ form: "Message is required for send behavior" });
-      return;
-    }
-    if (defaultAction.preset === "close") {
-      const close = defaultAction.options as { code?: number; reason?: string };
-      if (close.code !== undefined && (Number.isNaN(close.code) || !Number.isInteger(close.code) || (close.code !== 1000 && (close.code < 3000 || close.code > 4999)))) {
-        setErrors({ form: "WebSocket close code must be 1000 or between 3000 and 4999" });
-        return;
-      }
-      if (close.reason !== undefined && new TextEncoder().encode(close.reason).byteLength > 123) {
-        setErrors({ form: "WebSocket close reason must not exceed 123 UTF-8 bytes" });
-        return;
-      }
-    }
-    addListener({ endpointId: endpoint.endpointId, behavior: defaultAction });
+    const behavior = selectableBehaviorOptions("temp").find((option) => option.value === preset)?.behavior;
+    if (!behavior) return;
+    addListener({ endpointId: endpoint.endpointId, behavior });
     onClose();
   };
   return <form onSubmit={submit} className="msw-dt-ws-form">
-    <label className="msw-dt-label" htmlFor={`ws-action-${endpoint.endpointId}`}>Default action</label>
-    <Select id={`ws-action-${endpoint.endpointId}`} label="Default action" value={values.preset} onValueChange={(value) => setValues({ ...values, preset: (value ?? "send") as ListenerFormValues["preset"] })} options={[{ label: "send(message)", value: "send" }, { label: "close(code/reason)", value: "close" }]} />
-    {values.preset === "send" && <><label className="msw-dt-label" htmlFor="ws-message">Message</label><Input id="ws-message" value={values.message} onChange={(event) => setValues({ ...values, message: event.target.value })} /></>}
-    {values.preset === "close" && <><label className="msw-dt-label" htmlFor="ws-close-code">Close code</label><Input id="ws-close-code" type="number" value={values.code} onChange={(event) => setValues({ ...values, code: event.target.value })} /><label className="msw-dt-label" htmlFor="ws-close-reason">Close reason</label><Input id="ws-close-reason" value={values.reason} onChange={(event) => setValues({ ...values, reason: event.target.value })} /></>}
-    {errors.form && <p className="msw-dt-error-text">{errors.form}</p>}
+    <label className="msw-dt-label" htmlFor={`ws-action-${endpoint.endpointId}`}>Response behavior</label>
+    <Select id={`ws-action-${endpoint.endpointId}`} label="Response behavior" value={preset} onValueChange={(value) => setPreset(value ?? "send")} options={selectableBehaviorOptions("temp").map(({ label, value }) => ({ label, value }))} />
     <Button type="submit">Add listener</Button>
   </form>;
 };
@@ -103,15 +112,31 @@ const ListenerDialog = ({ endpoint }: { endpoint: WebSocketEndpointConfig }) => 
 
 const ListenerBehaviorSelect = ({ listener }: { listener: WebSocketListenerConfig }) => {
   const setEnabled = useHandlerStore((state) => state.setWebSocketListenerEnabled);
+  const setBehavior = useHandlerStore((state) => state.setWebSocketListenerBehavior);
+  const responseOptions = selectableBehaviorOptions(listener.info.source).map(({ label, value }) => ({ label, value }));
+  const currentValue = behaviorValue(listener.behavior);
+  const options = [
+    ...responseOptions.slice(0, 1),
+    { label: "Disable mock", value: "disable" },
+    ...responseOptions.slice(1),
+    ...(responseOptions.some((option) => option.value === currentValue) ? [] : [{ label: behaviorLabel(listener.behavior), value: currentValue }]),
+  ];
 
   return <Select
     label={`Behavior for ${listener.info.id}`}
-    value={listener.enabled ? "default" : "disable"}
-    options={[{ label: "Default", value: "default" }, { label: "Disable mock", value: "disable" }]}
+    value={listener.enabled ? currentValue : "disable"}
+    options={options}
     className="msw-dt-w-behavior-select"
     onValueChange={(value) => {
       if (!value) return;
-      setEnabled(listener.info.id, value !== "disable");
+      if (value === "disable") {
+        setEnabled(listener.info.id, false);
+        return;
+      }
+      const behavior = selectableBehaviorOptions(listener.info.source).find((option) => option.value === value)?.behavior;
+      if (!behavior) return;
+      setBehavior(listener.info.id, behavior);
+      setEnabled(listener.info.id, true);
     }}
   />;
 };
@@ -123,11 +148,11 @@ const EndpointRow = ({ endpoint }: { endpoint: WebSocketEndpointConfig }) => {
   const setEndpointEnabled = useHandlerStore((state) => state.setWebSocketEndpointEnabled);
   const isTemp = endpoint.info.source === "temp";
   return <>
-    <tr className="msw-dt-ws-endpoint-row">
-      <td><Button variant="ghost" className="msw-dt-ws-endpoint-trigger" aria-expanded={expanded} onClick={() => setExpanded(!expanded)}>{matcherLabel(endpoint.matcher)}</Button></td>
+    <tr className="msw-dt-ws-endpoint-row" onClick={() => setExpanded(!expanded)}>
+      <td><Button variant="ghost" className="msw-dt-ws-endpoint-trigger" aria-expanded={expanded}>{matcherLabel(endpoint.matcher)}</Button></td>
       <td>{endpoint.listeners.length}</td>
       <td><Toggle checked={endpoint.enabled} label={`Enable mock for ${matcherLabel(endpoint.matcher)}`} onChange={(enabled) => setEndpointEnabled(endpoint.endpointId, enabled)} /></td>
-      <td><Button variant="ghost" color="danger" disabled={!isTemp} title={isTemp ? "Delete endpoint" : "Endpoints generated from codebase cannot be deleted"} aria-label={isTemp ? `Delete endpoint ${matcherLabel(endpoint.matcher)}` : "Endpoints generated from codebase cannot be deleted"} className={isTemp ? "msw-dt-danger-text" : "msw-dt-disabled-text"} onClick={() => removeEndpoint(endpoint.endpointId)}><Trash2 size={16} /></Button></td>
+      <td onClick={(event) => event.stopPropagation()}><Button variant="ghost" color="danger" disabled={!isTemp} title={isTemp ? "Delete endpoint" : "Endpoints generated from codebase cannot be deleted"} aria-label={isTemp ? `Delete endpoint ${matcherLabel(endpoint.matcher)}` : "Endpoints generated from codebase cannot be deleted"} className={isTemp ? "msw-dt-danger-text" : "msw-dt-disabled-text"} onClick={() => removeEndpoint(endpoint.endpointId)}><Trash2 size={16} /></Button></td>
     </tr>
     {expanded && <tr className="msw-dt-ws-detail-row"><td colSpan={4}><div className="msw-dt-ws-listeners">
       <div className="msw-dt-ws-listener-toolbar"><ListenerDialog endpoint={endpoint} /></div>


### PR DESCRIPTION
## Abstract
<!-- What is the purpose of this PR? -->

## Issues
<!-- If there are any issues that this PR fixes, please list them here. -->
<!-- #(issue_number) -->

## Description
<!-- How does this PR fix the issues? -->
Add Behavior preset for WS

## Additional Context
<!-- Any other context that would be helpful to review the PR. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable WebSocket response presets, including echo, null response, no reply, and repeated message sequences.
  * Added controls to change listener behavior, disable mocking, and configure send or close responses.
  * Expanded supported WebSocket close codes.
  * Endpoint rows can now be expanded by clicking anywhere on the row.

* **Bug Fixes**
  * Temporary listeners now provide clearer validation feedback.
  * Pending WebSocket sequence messages are cancelled when connections close or the Dev Tool resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->