### PR TITLE
ci: raise coverage threshold to 85%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 85%
+        threshold: 0%
+    patch:
+      default:
+        target: 85%
+        threshold: 0%

--- a/packages/browser-cli/vitest.config.mts
+++ b/packages/browser-cli/vitest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
+      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
     },
   },
 });

--- a/packages/cli-core/vitest.config.mts
+++ b/packages/cli-core/vitest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/types.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
+      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
     },
   },
 });

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
+      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
     },
     projects: [
       {

--- a/packages/node-cli/vitest.config.mts
+++ b/packages/node-cli/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
+      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- add Codecov project and patch coverage gates at 85%
- raise Vitest statement, branch, function, and line thresholds to 85% across tested packages

## Verification
- yarn test:coverage
- Codecov YAML validator
- Prettier check