### PR TITLE
docs: add browser MCP agent guidance

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"]
+startup_timeout_sec = 120.0

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--browser-url=http://127.0.0.1:9222"
+      ]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,7 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": [
-        "-y",
-        "chrome-devtools-mcp@latest",
-        "--browser-url=http://127.0.0.1:9222"
-      ]
+      "args": ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ Chrome DevTools MCP server configured in `.codex/config.toml` for Codex or
    Chrome DevTools MCP for navigation, DOM inspection, console/network inspection,
    and verifying the user-visible result.
 5. After a mutation, inspect the same tab with Chrome DevTools MCP and verify the
-   application behavior. Run `msw-dev-tool-browser reset` when the scenario is
-   no longer needed.
+   application behavior. Run `msw-dev-tool-browser reset --cdp-url
+http://127.0.0.1:9222 --target <target-id>` when the scenario is no longer
+   needed.
 
 If the MCP server was added or its arguments changed, restart the MCP session
 before using it. Keep the Chrome process running while both the MCP server and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent instructions
+
+## Browser MCP workflow
+
+When working with the browser version of MSW Dev Tool, use the project-local
+Chrome DevTools MCP server configured in `.codex/config.toml` for Codex or
+`.mcp.json` for Claude Code.
+
+1. Start a separate Chrome profile with remote debugging enabled on
+   `http://127.0.0.1:9222`. Do not use a regular browsing profile. Use the
+   command for the current operating system:
+
+   ```bash
+   # macOS
+   open -na "Google Chrome" --args --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --user-data-dir=/private/tmp/chrome-debug-9222
+
+   # Linux
+   google-chrome --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug-9222
+   ```
+
+   On Windows PowerShell, run:
+
+   ```powershell
+   & "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --user-data-dir="$env:TEMP\chrome-debug-9222"
+   ```
+
+2. Open the application and confirm that the target tab calls
+   `setupDevToolWorker(...handlers)`.
+3. Use `msw-dev-tool-browser tabs --cdp-url http://127.0.0.1:9222` to obtain the
+   Browser CLI target ID. The Browser CLI target ID is not necessarily the same
+   as a Chrome DevTools MCP page ID; do not substitute one for the other.
+4. Use `@msw-dev-tool/browser-cli` for MSW handler and WebSocket mutations. Use
+   Chrome DevTools MCP for navigation, DOM inspection, console/network inspection,
+   and verifying the user-visible result.
+5. After a mutation, inspect the same tab with Chrome DevTools MCP and verify the
+   application behavior. Run `msw-dev-tool-browser reset` when the scenario is
+   no longer needed.
+
+If the MCP server was added or its arguments changed, restart the MCP session
+before using it. Keep the Chrome process running while both the MCP server and
+Browser CLI are in use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/docs/app/docs/(features)/browser-cli/page.mdx
+++ b/packages/docs/app/docs/(features)/browser-cli/page.mdx
@@ -10,6 +10,37 @@ import { Callout, Tabs } from "nextra/components";
 
 ## Configuration
 
+### Configure Chrome DevTools MCP
+
+For Codex, use `.codex/config.toml`:
+
+```toml copy
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest", "--browser-url=http://127.0.0.1:9222"]
+startup_timeout_sec = 120.0
+```
+
+For Claude Code, use the root `.mcp.json`:
+
+```json copy
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--browser-url=http://127.0.0.1:9222"
+      ]
+    }
+  }
+}
+```
+
+See the [Chrome DevTools MCP documentation](https://github.com/ChromeDevTools/chrome-devtools-mcp#connecting-to-a-running-chrome-instance)
+for other clients and connection options.
+
 ### Install and connect the runtime
 
 ```bash copy


### PR DESCRIPTION
## Summary
- Add project-local Chrome DevTools MCP configuration for Codex and Claude Code.
- Add shared browser workflow instructions and document the setup.

Fixes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chrome DevTools integration for browser inspection and navigation through supported AI development tools.
  * Added guidance for connecting to the browser CLI’s remote-debugging endpoint.
* **Documentation**
  * Added setup and usage instructions for Chrome DevTools MCP with Codex and Claude Code.
  * Documented browser testing workflows, including verifying changes and resetting the browser state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->