### PR TITLE
feat: add documentation review skill

### DIFF
--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: documentation-review
+description: Audit this repository's English developer documentation against its code, types, CLI and UI contracts, reporting evidence-based findings and actionable rewrites without editing documentation or source files.
+---
+
+# Documentation Review
+
+Use this skill for a full documentation audit or for reviewing a documentation change. The report follows the user's language, even though the source documentation is normally English.
+
+## Non-negotiable boundary
+
+- Review only. Do not edit documentation, source, tests, generated output, or configuration.
+- Do not invent a project term, API behavior, command syntax, or migration path. If the repository and authoritative ecosystem documentation do not establish a claim, report it as **unverified** rather than guessing.
+- Treat the repository's implementation as the primary source of truth. Use external sources for ecosystem terminology and standards, not to override the implementation.
+- Do not assign numeric scores or an overall grade. Group one root cause across affected locations and report each root cause once.
+
+## Modes and workflow
+
+1. Identify the requested scope, audience, and mode. For a full audit, inventory all relevant source docs. For a change review, inspect `git diff` and the surrounding pages, then check links and duplicated claims that the change may affect. Do not broaden a change review merely because another page could be improved.
+2. Build a document inventory and a user journey: entry point, prerequisites, install/setup, first successful result, recovery/reset, and next step. Mark canonical pages, hidden pages, redirects, README copies, and isolated or competing content using [project-profile.md](references/project-profile.md).
+3. Build a claim/evidence matrix. For every API, import, type, CLI command, JSON example, default, support claim, and project-specific term, verify in this order: package exports and public types; implementation and schemas; CLI/UI code; focused tests; then official ecosystem documentation. Use repository-wide `rg` search (excluding generated output and dependencies) before calling a term unsupported. Record the exact path, symbol, test, command, or URL used as evidence.
+4. Evaluate technical correctness and task completion before prose or formatting. Check copied examples end to end: install, working directory, prerequisites, command/code, expected result, cleanup, and whether examples on different pages conflict.
+5. Check information architecture, relevance, terminology, clarity, accessibility, safety, consistency, freshness, and maintainability with [rubric.md](references/rubric.md). Recommend a list, table, tab, callout, or separate section only when it materially improves scanning for the stated audience.
+6. Run proportionate read-only verification where possible. Prefer the repository's existing scripts (for example, docs build, typecheck, lint, or focused tests); record commands and failures. Never treat a successful build as proof that prose or runtime claims are correct.
+7. Produce the report format below. Include a concise limitation when a claim could not be exercised or when generated/runtime state was unavailable.
+
+## Evidence rules
+
+- Quote only the smallest useful fragment; prefer a paraphrase plus a file-and-line location.
+- Distinguish **implemented**, **documented**, **officially defined**, **runtime-observed**, and **unverified** claims.
+- A wording preference alone is not a finding. A terminology finding requires evidence from a public API/type/CLI/UI label, a recognized standard term (for example MSW, CDP, HTTP, or WebSocket), an official ecosystem source, or an explicit project definition.
+- When the same concept is named in multiple ways, show the canonical observed name and list the affected locations. Do not “simplify” a standard term if that changes its meaning.
+- Do not flag a valid project-specific term merely because it is unfamiliar; flag it only when it is undefined, unnecessary, inconsistent, or unsupported by repository evidence.
+- For dangerous commands or runtime mutations, verify scope, warning, isolated profile/data, and cleanup/termination instructions. For browser CLI work, follow the repository's separate Chrome profile and target-selection procedure in `AGENTS.md`; use Browser CLI for mutations and Chrome DevTools inspection for the visible result.
+
+## Severity
+
+Use exactly one severity per root cause:
+
+- `blocker`: cannot run, contradicts the current API, or creates data/security/operational risk.
+- `high`: prevents a core task or produces a wrong result; a missing prerequisite or recovery path can be high when the task commonly fails without it.
+- `medium`: causes substantial guessing, backtracking, or terminology confusion but has a reliable workaround.
+- `low`: a non-blocking clarity, format, accessibility, or consistency improvement.
+
+Use the smallest severity supported by evidence. Do not elevate a preference to `medium` or higher.
+
+## Required report
+
+1. **Audit scope and verification** — audience, full/change mode, source paths, commands/tests/builds run, and runtime checks (if any).
+2. **Findings by severity** — highest severity first. Each finding must include:
+   - **Location:** path and heading, command, or line range.
+   - **Problem:** one precise statement.
+   - **Evidence:** code/type/schema/test, official usage, or execution result with an exact reference.
+   - **User impact:** what the reader cannot do, may misunderstand, or may put at risk.
+   - **Recommended structure and replacement wording:** the smallest actionable change; preserve verified names and syntax. If structure is already sound, say so and give only replacement wording.
+3. **Missing user tasks** — tasks a target reader needs but cannot complete from the reviewed docs.
+4. **Unverified or remaining limits** — claims not exercised, inaccessible runtime state, or external sources not checked, with the reason.
+
+If no evidence-backed issue remains, write `No findings` and still state residual verification limits.
+
+Read [rubric.md](references/rubric.md) for the detailed review criteria and [project-profile.md](references/project-profile.md) before auditing this repository's docs.

--- a/.agents/skills/documentation-review/agents/openai.yaml
+++ b/.agents/skills/documentation-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Documentation Review"
+  short_description: "Audit project docs against code and style"
+  default_prompt: "Use $documentation-review to audit the requested English developer documentation without editing it."

--- a/.agents/skills/documentation-review/references/project-profile.md
+++ b/.agents/skills/documentation-review/references/project-profile.md
@@ -1,0 +1,46 @@
+# MSW Dev Tool project profile
+
+This profile keeps recurring repository facts in one place. Re-check implementation details when the branch changes; this is a routing aid, not a substitute for source verification.
+
+## Documentation inventory and canonical relationships
+
+- Root overview: `README.md` (package overview and links to the deployed docs).
+- Published package contracts: `packages/*/README.md`, especially `packages/core/README.md`, `packages/react/README.md`, `packages/node-cli/README.md`, and `packages/browser-cli/README.md`.
+- Canonical site source: `packages/docs/app/docs/**/page.mdx`.
+- Site navigation and visibility: `packages/docs/app/docs/_meta.tsx`. `handler-table`, `debugger`, `tools`, and `temp-handler` are hidden pages; do not assume hidden means deleted. Check links and the page source before calling one orphaned or obsolete.
+- Site project scaffold: `packages/docs/README.md`. Treat the default create-next-app text as unrelated scaffold unless the task explicitly concerns developing the docs app.
+- Generated/derived content: `packages/docs/.next/**` and `packages/docs/public/_pagefind/**`; use them as build evidence only and never recommend editing them.
+- Repository browser workflow: `AGENTS.md`; it defines the separate Chrome profile, CDP port, target-ID distinction, mutation tool, verification tool, and reset command.
+
+When a page and a README repeat a command or schema, compare both to the implementation and recommend a canonical location rather than accepting either copy by default.
+
+## Package and API truth sources
+
+- `packages/core/package.json` exports `@msw-dev-tool/core/browser`, `/node`, `/shared`, and `/msw`; inspect these exports and the corresponding `packages/core/src/**/index.ts` files before accepting an import.
+- `packages/core/src/browser/index.ts` and `packages/core/src/node/index.ts` define browser/node setup entry points. Check whether setup returns a promise and what lifecycle/cleanup it exposes.
+- `packages/core/src/msw/**` and `packages/core/src/shared/**` define WebSocket handlers, behavior, response schemas, IDs, defaults, and validation.
+- `packages/react/package.json` exports the React entry point and `./msw-dev-tool.css`; inspect `packages/react/src/**` for visible labels and supported UI operations.
+- `packages/cli-core/src/commands.ts`, `args.ts`, `types.ts`, and `output.ts` are the shared CLI contract: command names, usage, positionals, flags, JSON parsing, and output shape.
+- `packages/node-cli/src/**` and `packages/node-cli/bin/msw-dev-tool.js` define the Node executable and session selection. `packages/browser-cli/src/**` and `packages/browser-cli/bin/msw-dev-tool-browser.js` define the CDP executable, required flags, target selection, and browser behavior.
+- Focused tests in the same package are strong evidence for edge cases and output contracts; use tests after the implementation and schemas, not instead of them.
+
+## Verification commands
+
+Use only commands relevant to the reviewed claim and record the exact command/result:
+
+```bash
+yarn workspace docs build
+yarn workspace @msw-dev-tool/core typecheck
+yarn workspace @msw-dev-tool/cli-core typecheck
+yarn workspace @msw-dev-tool/node-cli typecheck
+yarn workspace @msw-dev-tool/browser-cli typecheck
+yarn workspace @msw-dev-tool/core test --run
+yarn workspace @msw-dev-tool/node-cli test --run
+yarn workspace @msw-dev-tool/browser-cli test --run
+```
+
+The docs build may regenerate ignored or derived files; do not edit or commit those outputs during a review. If a command is unavailable or expensive, report it as not run instead of inferring success.
+
+## Browser runtime checks
+
+Only perform a live browser check when the request requires runtime evidence and the user has supplied or authorized the environment. Follow `AGENTS.md` exactly: start the separate profile on `http://127.0.0.1:9222`, confirm the tab calls `setupDevToolWorker(...handlers)`, obtain the Browser CLI target ID with `msw-dev-tool-browser tabs`, use Browser CLI for mutations, inspect the same tab with Chrome DevTools MCP, and reset the target after the scenario. Do not substitute a Chrome DevTools page ID for the Browser CLI target ID.

--- a/.agents/skills/documentation-review/references/rubric.md
+++ b/.agents/skills/documentation-review/references/rubric.md
@@ -1,0 +1,54 @@
+# Documentation review rubric
+
+Use this rubric after technical claims have been checked. It is a decision aid, not a scorecard. Report only findings that have evidence and a user consequence.
+
+## Quality dimensions
+
+### Technical accuracy
+
+Check import paths, exported names, function signatures, promise/`await` behavior, CLI command names and positional arguments, JSON schemas, defaults, supported features, and stated version limits against the repository. A claim that cannot be checked in code or tests is **unverified**, not automatically wrong.
+
+### Executability and task completion
+
+Trace install to first success. A runnable example identifies prerequisites, working directory, environment, expected output, and cleanup/reset. Check that examples on different pages use compatible IDs, flags, package versions, and state. Check normal flow, common failure, recovery, and reset/cleanup paths.
+
+### Information architecture and discoverability
+
+Classify each page as tutorial, how-to, reference, or explanation using the [Diátaxis application guide](https://www.diataxis.fr/application/). Check that title, headings, links, navigation, next steps, hidden pages, redirects, README summaries, and site pages form a usable path rather than competing or isolated copies.
+
+### Relevance and information density
+
+Remove or relocate boilerplate, repeated prose, stale scaffold text, implementation detail that does not support a decision, and content unrelated to the reader's task. Put the decision and prerequisites early; keep one dominant purpose per page.
+
+### Terminology
+
+Prefer ordinary words where they preserve meaning. Preserve ecosystem terms such as MSW, CDP, HTTP, WebSocket, `sessionStorage`, and `setupDevToolWorker` when they are the established contract. Accept a project-specific term only when it is visible in code/UI/CLI or explicitly defined. Check first-use definitions, one name per concept, and no overloaded name for distinct concepts.
+
+### Clarity and readability
+
+Apply the [Google developer documentation style guide](https://developers.google.com/style) and [Kubernetes style guide](https://kubernetes.io/docs/contribute/style/style-guide/): direct sentences, concrete subjects, active voice, defined abbreviations, and unambiguous references. Flag long paragraphs that join independent items with commas or conjunctions when they make the choices or sequence hard to scan. Use a list for parallel items or steps, a table for meaningful comparisons, tabs or separate sections for environment alternatives, and a callout for prerequisites or warnings. Do not force a structure when a paragraph is easier to read.
+
+### Consistency and drift
+
+Check product/package names, command spelling, casing, link labels, JSON fields, and behavior descriptions across root README, package READMEs, and site pages. Identify a canonical source and recommend a summary/link elsewhere when the same specification is duplicated.
+
+### Freshness and version clarity
+
+Check deprecated packages, current support, peer/version ranges, migration paths, and future/roadmap language. Do not treat a roadmap promise as an implemented feature.
+
+### Accessibility
+
+Check descriptive link text, sequential headings, useful image alt text, and table semantics. Ensure required information is not communicated only by color, position, or an image.
+
+### Safety and operations
+
+For remote debugging, file deletion, unbounded repetition, or external calls, require a bounded scope, explicit warning, isolated data/profile where appropriate, and a stop/reset/cleanup procedure. A command that is technically valid can still be a high-severity finding when it can affect a regular browser profile or real data unexpectedly.
+
+### Maintainability
+
+Identify which docs must change when a public export, CLI schema, UI label, or generated page changes. Distinguish generated output from a manually maintained canonical source and avoid recommending edits to generated artifacts.
+
+## External references
+
+- [Rustdoc: How to write documentation](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html) — examples should explain the public contract and be runnable where possible.
+- Use official MSW, Chrome DevTools/CDP, and other ecosystem documentation for external terms and setup semantics. Cite the exact page checked in the report.


### PR DESCRIPTION
## Summary
- add the repository-local documentation-review skill
- define evidence-first rubric, project profile, severity, and report format
- expose the skill through OpenAI metadata and the existing Claude symlink

## Validation
- quick_validate.py passed
- docs build passed
- core, cli-core, node-cli, and browser-cli typechecks passed
- core, node-cli, and browser-cli tests passed
- no repository documentation was modified