### PR TITLE
docs: add functional change description PR skill

### DIFF
--- a/.agents/skills/write-pr/SKILL.md
+++ b/.agents/skills/write-pr/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: write-pr
+description: Entry point for PR-writing workflows and their specialized skills.
+---
+
+# Write PR
+
+This is the placeholder entry point for future PR-writing workflows. Specialized PR skills should own the details of each PR artifact and be invoked when that artifact is requested.
+
+The current scope is routing only; use the listed subskill for the supported artifact instead of generating PR content directly from this placeholder.
+
+## Available subskills
+
+- `functional-change-description-skill` — generate a user-facing feature specification from changed test cases and the implementation diff. Invoke it for the PR `Spec` section.
+
+Delegate functional-change description work to [functional-change-description-skill](functional-change-description-skill/SKILL.md).

--- a/.agents/skills/write-pr/functional-change-description-skill/SKILL.md
+++ b/.agents/skills/write-pr/functional-change-description-skill/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: functional-change-description-skill
+description: Generate a PR feature specification from changed test cases and the implementation diff, grouped around observable user behavior.
+---
+
+# Functional Change Description
+
+Invoke this skill with `$functional-change-description-skill` in Codex or `/functional-change-description-skill` in Claude.
+
+Generate the feature specification for a PR from these inputs:
+
+- the changed test cases, including their titles, setup, actions, and assertions;
+- the implementation diff associated with those tests.
+
+The implementation diff explains what was changed. The tests establish which behavior is intentionally observable. Do not require test execution results as an input.
+
+## Workflow
+
+1. Identify the base and changed behavior from the implementation diff. Read the relevant surrounding code when a diff fragment is insufficient.
+2. Read every changed test scenario and trace its actor or caller, action, condition, and observable outcome. Prefer the product-facing flow: what a UI user, CLI user, API consumer, or application author can do or observe.
+3. Use the implementation diff to validate the behavior described by the tests. Treat implementation-only refactors, new helpers, and internal state changes as evidence only; do not describe them as features unless a test or public contract makes them observable.
+4. Classify each supported behavior as:
+   - **Removed Spec** — an existing observable behavior is no longer available or is explicitly deleted.
+   - **Changed Spec** — an existing observable behavior remains but its input, condition, output, or user-visible result changed. Show the behavior before and after.
+   - **Added Spec** — a new observable behavior is introduced without replacing an existing behavior.
+   A new or expanded regression test does not by itself make a behavior added. If the implementation preserves an existing contract and the test only protects it, leave that behavior out of the output.
+5. Group related changes across packages by the user's flow and remove duplicate descriptions. Mention package boundaries only when they clarify the flow.
+6. Do not infer behavior that is absent from both the changed tests and the implementation diff. If the evidence is ambiguous, omit the claim rather than speculate.
+7. Return only the following Markdown structure. Use `None` for every section with no supported entries:
+
+```md
+### Removed Spec
+- ...
+
+### Changed Spec
+| Before | After |
+| --- | --- |
+| ... | ... |
+
+### Added Spec
+- ...
+```
+
+Write each entry in terms of the behavior a user or caller can observe, not internal function or store names. Preserve concrete details that the evidence establishes, such as supported request fields, response values, status, headers, fallback behavior, or validation outcomes. Do not add implementation rationale, test-run claims, or unsupported limitations to the output.

--- a/.agents/skills/write-pr/functional-change-description-skill/SKILL.md
+++ b/.agents/skills/write-pr/functional-change-description-skill/SKILL.md
@@ -23,21 +23,24 @@ The implementation diff explains what was changed. The tests establish which beh
    - **Removed Spec** — an existing observable behavior is no longer available or is explicitly deleted.
    - **Changed Spec** — an existing observable behavior remains but its input, condition, output, or user-visible result changed. Show the behavior before and after.
    - **Added Spec** — a new observable behavior is introduced without replacing an existing behavior.
-   A new or expanded regression test does not by itself make a behavior added. If the implementation preserves an existing contract and the test only protects it, leave that behavior out of the output.
+     A new or expanded regression test does not by itself make a behavior added. If the implementation preserves an existing contract and the test only protects it, leave that behavior out of the output.
 5. Group related changes across packages by the user's flow and remove duplicate descriptions. Mention package boundaries only when they clarify the flow.
 6. Do not infer behavior that is absent from both the changed tests and the implementation diff. If the evidence is ambiguous, omit the claim rather than speculate.
 7. Return only the following Markdown structure. Use `None` for every section with no supported entries:
 
 ```md
 ### Removed Spec
+
 - ...
 
 ### Changed Spec
+
 | Before | After |
-| --- | --- |
-| ... | ... |
+| ------ | ----- |
+| ...    | ...   |
 
 ### Added Spec
+
 - ...
 ```
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,10 @@
 
 <!-- How does this PR fix the issues? -->
 
+## Spec
+
+<!-- Fill this section with run functional-change-description-skill -->
+
 ## Additional Context
 
 <!-- Any other context that would be helpful to review the PR. -->


### PR DESCRIPTION
## Abstract

Add the `write-pr` routing skill and its `functional-change-description-skill` subskill.

## Issues

#207

## Description

- Add the top-level `write-pr` skill placeholder.
- Add instructions for generating user-facing functional change descriptions from tests and implementation diffs.
- Add the `## Spec` section to the pull request template.

## Spec

None

## Additional Context

Documentation-only change. Skill validation and whitespace checks pass.