### PR TITLE
test: raise coverage thresholds to 95%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,9 @@ coverage:
   status:
     project:
       default:
-        target: 85%
+        target: 95%
         threshold: 0%
     patch:
       default:
-        target: 85%
+        target: 95%
         threshold: 0%

--- a/packages/browser-cli/src/cdp-client.test.ts
+++ b/packages/browser-cli/src/cdp-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const socketState = vi.hoisted(() => {
   const sockets: Array<any> = [];
@@ -6,7 +6,10 @@ const socketState = vi.hoisted(() => {
     private listeners = new Map<string, Array<(...args: any[]) => void>>();
     public constructor(_: string) {
       sockets.push(this);
-      queueMicrotask(() => this.emit("open"));
+      queueMicrotask(() => {
+        if (state.connection === "open") this.emit("open");
+        if (state.connection === "error") this.emit("error", new Error("connect failed"));
+      });
     }
     public on(name: string, listener: (...args: any[]) => void) {
       this.add(name, listener);
@@ -30,18 +33,34 @@ const socketState = vi.hoisted(() => {
       this.listeners.set(name, [...(this.listeners.get(name) ?? []), listener]);
     }
     public send(_: string, callback: (error?: Error) => void) {
-      callback(state.sendError ? new Error("send failed") : undefined);
+      if (state.sendThrow) throw new Error("socket is unavailable");
+      const complete = () => callback(state.sendError ? new Error("send failed") : undefined);
+      if (state.sendDelay) setTimeout(complete, state.sendDelay);
+      else complete();
     }
     public close() {
       this.emit("close");
     }
     public terminate() {}
   }
-  const state = { sendError: false };
+  const state = {
+    sendError: false,
+    sendThrow: false,
+    sendDelay: 0,
+    connection: "open" as "open" | "error" | "pending",
+  };
   return { sockets, FakeSocket, state };
 });
 vi.mock("ws", () => ({ default: socketState.FakeSocket }));
 import { CdpClient } from "./cdp";
+
+afterEach(() => {
+  vi.useRealTimers();
+  socketState.state.sendError = false;
+  socketState.state.sendThrow = false;
+  socketState.state.sendDelay = 0;
+  socketState.state.connection = "open";
+});
 
 describe("CdpClient protocol transport", () => {
   it("resolves a response that matches the pending CDP command", async () => {
@@ -116,6 +135,57 @@ describe("CdpClient protocol transport", () => {
     socketState.state.sendError = true;
     const client = await CdpClient.connect("ws://test");
     await expect(client.call("Runtime")).rejects.toThrow("send failed");
-    socketState.state.sendError = false;
+  });
+
+  it("rejects a command when sending to the CDP socket throws synchronously", async () => {
+    socketState.state.sendThrow = true;
+    const client = await CdpClient.connect("ws://test");
+
+    await expect(client.call("Runtime")).rejects.toThrow("socket is unavailable");
+  });
+
+  it("ignores a delayed send error after the command has already timed out", async () => {
+    vi.useFakeTimers();
+    socketState.state.sendDelay = 10;
+    socketState.state.sendError = true;
+    const client = await CdpClient.connect("ws://test");
+    const pending = expect(client.call("Runtime", undefined, 5)).rejects.toThrow(
+      "Timed out waiting for CDP Runtime after 5ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(5);
+    await pending;
+    await vi.advanceTimersByTimeAsync(5);
+    client.close();
+  });
+
+  it("ignores CDP events that do not identify a pending command", async () => {
+    const client = await CdpClient.connect("ws://test");
+    const socket = socketState.sockets.at(-1)!;
+    const pending = client.call("Runtime.evaluate");
+
+    socket.emit("message", JSON.stringify({ result: { value: "ignored" } }));
+    socket.emit("message", JSON.stringify({ id: 1, result: { value: "ok" } }));
+
+    await expect(pending).resolves.toEqual({ value: "ok" });
+    client.close();
+  });
+
+  it("rejects when Chrome fails before opening the CDP socket", async () => {
+    socketState.state.connection = "error";
+
+    await expect(CdpClient.connect("ws://test")).rejects.toThrow("connect failed");
+  });
+
+  it("rejects when Chrome does not open the CDP socket before the timeout", async () => {
+    vi.useFakeTimers();
+    socketState.state.connection = "pending";
+
+    const connection = expect(CdpClient.connect("ws://test", 5)).rejects.toThrow(
+      "Timed out while connecting to Chrome after 5ms",
+    );
+    await vi.advanceTimersByTimeAsync(5);
+
+    await connection;
   });
 });

--- a/packages/browser-cli/src/index.test.ts
+++ b/packages/browser-cli/src/index.test.ts
@@ -47,6 +47,27 @@ describe("browser-cli", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
+  it("prints command help when called without a command", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runCli([]);
+
+    expect(write).toHaveBeenCalledWith(expect.stringContaining("msw-dev-tool-browser"));
+  });
+
+  it("prints command help when --help is passed", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runCli(["--help"]);
+
+    expect(write).toHaveBeenCalledWith(expect.stringContaining("msw-dev-tool-browser"));
+  });
+
+  it("requires a CDP URL for commands other than help", async () => {
+    await expect(runCli(["list"])).rejects.toThrow("Missing required --cdp-url");
+    expect(cdp.listTargets).not.toHaveBeenCalled();
+  });
+
   it("lists page targets without exposing non-page targets", async () => {
     await expect(
       runWithJsonOutput(["tabs", "--cdp-url", "http://localhost:9222"]),
@@ -61,6 +82,24 @@ describe("browser-cli", () => {
     await expect(
       runCli(["list", "--cdp-url", "http://localhost:9222", "--target", "missing"]),
     ).rejects.toThrow("No page target found for id: missing");
+    expect(cdp.connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects a page target without a debugger URL", async () => {
+    cdp.listTargets.mockResolvedValueOnce([
+      { id: "page-a", type: "page", title: "Example", url: "http://localhost:3000" },
+    ]);
+
+    await expect(
+      runCli(["list", "--cdp-url", "http://localhost:9222", "--target", "page-a"]),
+    ).rejects.toThrow("No page target found for id: page-a");
+    expect(cdp.connect).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown command after selecting a page target", async () => {
+    await expect(
+      runCli(["unknown", "--cdp-url", "http://localhost:9222", "--target", "page-a"]),
+    ).rejects.toThrow("Unknown command: unknown");
     expect(cdp.connect).not.toHaveBeenCalled();
   });
 

--- a/packages/browser-cli/src/session.test.ts
+++ b/packages/browser-cli/src/session.test.ts
@@ -333,6 +333,16 @@ describe("CdpBrowserCliSession", () => {
     );
   });
 
+  it("falls back to the generic evaluation error when exception details are empty", async () => {
+    const client = {
+      call: vi.fn().mockResolvedValue({ exceptionDetails: {} }),
+    } as unknown as CdpClient;
+
+    await expect(new CdpBrowserCliSession(client).describe()).rejects.toThrow(
+      "CDP evaluation failed",
+    );
+  });
+
   it("returns the WebSocket endpoints available to the CLI caller", async () => {
     const { client } = createWebSocketBridge();
 

--- a/packages/browser-cli/vitest.config.mts
+++ b/packages/browser-cli/vitest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
+      thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },
     },
   },
 });

--- a/packages/cli-core/src/index.test.ts
+++ b/packages/cli-core/src/index.test.ts
@@ -709,6 +709,99 @@ describe("shared CLI commands", () => {
     ).rejects.toThrow("WebSocket endpoint not found");
   });
 
+  it("rejects get without a handler ID", async () => {
+    await expect(
+      findCommand("get")!.execute(
+        { session: createSession() },
+        { flags: {}, positionals: ["get"] },
+      ),
+    ).rejects.toThrow("Usage: get <id>");
+  });
+
+  it("rejects set-behavior without a behavior value", async () => {
+    await expect(
+      findCommand("set-behavior")!.execute(
+        { session: createSession() },
+        { flags: {}, positionals: ["set-behavior", "a"] },
+      ),
+    ).rejects.toThrow("Usage: set-behavior <id> <behavior>");
+  });
+
+  it("rejects set-mock-enabled without an enabled value", async () => {
+    await expect(
+      findCommand("set-mock-enabled")!.execute(
+        { session: createSession() },
+        { flags: {}, positionals: ["set-mock-enabled"] },
+      ),
+    ).rejects.toThrow("Usage: set-mock-enabled <true|false>");
+  });
+
+  it("rejects an event-enabled command without all required arguments", async () => {
+    await expect(
+      findCommand("ws-set-listener-event-enabled")!.execute(
+        { session: createSession() },
+        { flags: {}, positionals: ["ws-set-listener-event-enabled", wsListener.info.id] },
+      ),
+    ).rejects.toThrow("Usage: ws-set-listener-event-enabled");
+  });
+
+  it("rejects an event-enabled command with a non-boolean value", async () => {
+    await expect(
+      findCommand("ws-set-listener-event-enabled")!.execute(
+        { session: createSession() },
+        {
+          flags: {},
+          positionals: [
+            "ws-set-listener-event-enabled",
+            wsListener.info.id,
+            "chat/message",
+            "maybe",
+          ],
+        },
+      ),
+    ).rejects.toThrow("enabled must be true or false");
+  });
+
+  it("rejects an event-behavior command without JSON input", async () => {
+    await expect(
+      findCommand("ws-set-listener-event-behavior")!.execute(
+        { session: createSession() },
+        {
+          flags: {},
+          positionals: ["ws-set-listener-event-behavior", wsListener.info.id, "chat/message"],
+        },
+      ),
+    ).rejects.toThrow("Usage: ws-set-listener-event-behavior");
+  });
+
+  it("rejects an event-custom-response command without JSON input", async () => {
+    await expect(
+      findCommand("ws-set-listener-event-custom-response")!.execute(
+        { session: createSession() },
+        {
+          flags: {},
+          positionals: [
+            "ws-set-listener-event-custom-response",
+            wsListener.info.id,
+            "chat/message",
+          ],
+        },
+      ),
+    ).rejects.toThrow("Usage: ws-set-listener-event-custom-response");
+  });
+
+  it("rejects an event-response command without JSON input", async () => {
+    await expect(
+      findCommand("ws-set-listener-event-response")!.execute(
+        { session: createSession() },
+        {
+          flags: {},
+          positionals: ["ws-set-listener-event-response", wsListener.info.id, "chat/message"],
+        },
+      ),
+    ).rejects.toThrow("Usage: ws-set-listener-event-response");
+  });
+
   it.each([
     ["ws-add-endpoint", ["ws-add-endpoint"]],
     ["ws-add-listener", ["ws-add-listener", wsEndpoint.endpointId]],

--- a/packages/cli-core/vitest.config.mts
+++ b/packages/cli-core/vitest.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/types.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
+      thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },
     },
   },
 });

--- a/packages/core/src/browser/handlerStore.test.ts
+++ b/packages/core/src/browser/handlerStore.test.ts
@@ -369,6 +369,70 @@ describe("browser control bridge", () => {
     ).toMatchObject({ value: "response" });
   });
 
+  it("rejects an event behavior change when the event branch is absent", async () => {
+    await setupDevToolWorker();
+    const endpointId = handlerStore.getState().addTempWebSocketEndpoint({
+      endpoint: "ws://browser.test/missing-event-behavior",
+      matcher: { kind: "string", value: "ws://browser.test/missing-event-behavior" },
+    });
+    const listenerId = handlerStore.getState().addTempWebSocketListener({ endpointId });
+
+    await expect(
+      Promise.resolve().then(() =>
+        getBridge().setWebSocketListenerEventBehavior(listenerId, "missing", {
+          preset: "echo",
+        }),
+      ),
+    ).rejects.toThrow("WebSocket listener event not found");
+  });
+
+  it("rejects an event enabled-state change when the event branch is absent", async () => {
+    await setupDevToolWorker();
+    const endpointId = handlerStore.getState().addTempWebSocketEndpoint({
+      endpoint: "ws://browser.test/missing-event-enabled",
+      matcher: { kind: "string", value: "ws://browser.test/missing-event-enabled" },
+    });
+    const listenerId = handlerStore.getState().addTempWebSocketListener({ endpointId });
+
+    expect(() =>
+      getBridge().setWebSocketListenerEventEnabled(listenerId, "missing", false),
+    ).toThrow("WebSocket listener event not found");
+  });
+
+  it("rejects an event custom-response change when the event branch is absent", async () => {
+    await setupDevToolWorker();
+    const endpointId = handlerStore.getState().addTempWebSocketEndpoint({
+      endpoint: "ws://browser.test/missing-event-custom",
+      matcher: { kind: "string", value: "ws://browser.test/missing-event-custom" },
+    });
+    const listenerId = handlerStore.getState().addTempWebSocketListener({ endpointId });
+
+    expect(() =>
+      getBridge().setWebSocketListenerEventCustomResponse(listenerId, "missing", {
+        type: "send",
+        dataType: "string",
+        value: "custom",
+      }),
+    ).toThrow("WebSocket listener event not found");
+  });
+
+  it("rejects an event response change when the event branch is absent", async () => {
+    await setupDevToolWorker();
+    const endpointId = handlerStore.getState().addTempWebSocketEndpoint({
+      endpoint: "ws://browser.test/missing-event-response",
+      matcher: { kind: "string", value: "ws://browser.test/missing-event-response" },
+    });
+    const listenerId = handlerStore.getState().addTempWebSocketListener({ endpointId });
+
+    expect(() =>
+      getBridge().setWebSocketListenerEventResponse(listenerId, "missing", {
+        type: "send",
+        dataType: "string",
+        value: "response",
+      }),
+    ).toThrow("WebSocket listener event not found");
+  });
+
   it("keeps HTTP temp metadata when hydrating WebSocket state", async () => {
     await setupDevToolWorker(http.get("/hydrate", () => HttpResponse.json({ ok: true })));
     const state = handlerStore.getState();
@@ -453,6 +517,10 @@ describe("browser control bridge", () => {
     handlerStore.setState({ worker: initial.worker });
     handlerStore.setState({ flattenHandlers: initial.flattenHandlers });
     handlerStore.setState({ restHandlers: ["unsupported"] });
+    handlerStore.setState({
+      webSocketEndpoints: initial.webSocketEndpoints,
+      webSocketListeners: initial.webSocketListeners,
+    });
     handlerStore.setState((current) => ({
       restHandlers: [...current.restHandlers, "another"],
     }));

--- a/packages/core/src/node/snapshot/controller.test.ts
+++ b/packages/core/src/node/snapshot/controller.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import fsPromises from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { FlattenHandler, HttpHandlerBehavior, HttpMethod } from "../../shared/types";
@@ -8,6 +9,7 @@ import { readSnapshot, writeSnapshot } from "./file";
 import { bumpSnapshot } from "./serialize";
 import { SessionController } from "./controller";
 import { getSessionPathForPid } from "./sessionPath";
+import { SessionSnapshot } from "./types";
 
 const tempDirs: string[] = [];
 
@@ -39,9 +41,11 @@ describe("SessionController", () => {
   it("does nothing when synchronized before start", async () => {
     const onSnapshot = vi.fn();
     const controller = new SessionController({ onSnapshot, onReset: () => [] });
+    expect(controller.sessionPath).toBeNull();
     await expect(controller.sync()).resolves.toBeUndefined();
     await expect(controller.publishWebSocket(() => [])).resolves.toBeUndefined();
     expect(onSnapshot).not.toHaveBeenCalled();
+    await controller.dispose();
   });
 
   it("publishes discovered WebSocket state only when it changes", async () => {
@@ -70,6 +74,15 @@ describe("SessionController", () => {
 
     expect(published.state.webSocket).toEqual(webSocket);
     expect((await readSnapshot(sessionPath))?.revision).toBe(published.revision);
+
+    const withoutWebSocket = {
+      ...published,
+      revision: published.revision + 1,
+      state: { ...published.state, webSocket: undefined },
+    } as typeof published;
+    await writeSnapshot(sessionPath, withoutWebSocket);
+    await controller.publishWebSocket(() => []);
+    expect((await readSnapshot(sessionPath))?.state.webSocket).toBeUndefined();
     await controller.dispose();
   });
 
@@ -232,11 +245,13 @@ describe("SessionController", () => {
     expect(onReset).toHaveBeenCalledTimes(1);
     expect((await readSnapshot(sessionPath))?.state.pendingReset).toBeUndefined();
 
-    // Second sync on the same revision exercises the "lastWrittenRevision === revision" branch.
+    // A repeated sync on the acknowledged revision remains a no-op.
     await controller.sync();
     expect(onReset).toHaveBeenCalledTimes(1);
 
-    await controller.dispose();
+    const disposal = controller.dispose();
+    const repeatedDisposal = controller.dispose();
+    await Promise.all([disposal, repeatedDisposal]);
     expect(fs.existsSync(sessionPath)).toBe(false);
     expect(fs.existsSync(`${sessionPath}.lock`)).toBe(false);
   });
@@ -278,6 +293,76 @@ describe("SessionController", () => {
     expect(onResetWebSocket).toHaveBeenCalledTimes(1);
     expect((await readSnapshot(sessionPath))?.state.webSocket).toEqual([]);
     await controller.dispose();
+  });
+
+  it("does not overwrite a reset acknowledged by another process", async () => {
+    const sessionPath = createTempSessionPath();
+    let resetRequest: SessionSnapshot | null = null;
+    const onReset = vi.fn(() => {
+      const acknowledged = {
+        ...resetRequest!,
+        revision: resetRequest!.revision + 1,
+        state: { ...resetRequest!.state, pendingReset: undefined },
+      } satisfies SessionSnapshot;
+      fs.writeFileSync(sessionPath, `${JSON.stringify(acknowledged)}\n`, "utf8");
+      return [createFlattenHandler()];
+    });
+    const controller = new SessionController({ onSnapshot: vi.fn(), onReset });
+
+    await controller.start([createFlattenHandler()]);
+    resetRequest = bumpSnapshot((await readSnapshot(sessionPath))!, {
+      pendingReset: true,
+    });
+    await writeSnapshot(sessionPath, resetRequest);
+
+    await controller.sync();
+
+    const acknowledged = (await readSnapshot(sessionPath))!;
+    expect(onReset).toHaveBeenCalledOnce();
+    expect(acknowledged.revision).toBe(resetRequest.revision + 1);
+    expect(acknowledged.state.pendingReset).toBeUndefined();
+    expect(acknowledged.state.flattenHandlers).toEqual(resetRequest.state.flattenHandlers);
+    await controller.dispose();
+  });
+
+  it("recreates an empty snapshot when the watched session file is missing", async () => {
+    const sessionPath = createTempSessionPath();
+    const controller = new SessionController({ onSnapshot: vi.fn(), onReset: () => [] });
+
+    await controller.start([createFlattenHandler()]);
+    const startWatching = (
+      controller as unknown as { startWatching: () => Promise<void> }
+    ).startWatching.bind(controller);
+    const access = vi
+      .spyOn(fsPromises, "access")
+      .mockRejectedValueOnce(Object.assign(new Error("missing"), { code: "ENOENT" }));
+
+    try {
+      await expect(startWatching()).resolves.toBeUndefined();
+      expect((await readSnapshot(sessionPath))?.state.flattenHandlers).toEqual([]);
+    } finally {
+      access.mockRestore();
+      await controller.dispose();
+    }
+  });
+
+  it("propagates unexpected errors while checking the watched session file", async () => {
+    createTempSessionPath();
+    const controller = new SessionController({ onSnapshot: vi.fn(), onReset: () => [] });
+
+    await controller.start([createFlattenHandler()]);
+    const startWatching = (
+      controller as unknown as { startWatching: () => Promise<void> }
+    ).startWatching.bind(controller);
+    const accessError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const access = vi.spyOn(fsPromises, "access").mockRejectedValueOnce(accessError);
+
+    try {
+      await expect(startWatching()).rejects.toBe(accessError);
+    } finally {
+      access.mockRestore();
+      await controller.dispose();
+    }
   });
 
   it("recovers previous WebSocket state when a reset snapshot omits it", async () => {
@@ -361,7 +446,7 @@ describe("SessionController", () => {
     expect(onSnapshot).toHaveBeenCalledOnce();
     expect(onSnapshot).toHaveBeenCalledWith(next);
 
-    // Second sync with same revision triggers the lastWrittenRevision === revision branch (L84).
+    // A second sync with the same revision remains a no-op.
     await controller.sync();
     expect(onSnapshot).toHaveBeenCalledOnce();
     await controller.dispose();

--- a/packages/core/src/node/snapshot/controller.ts
+++ b/packages/core/src/node/snapshot/controller.ts
@@ -35,7 +35,6 @@ export class SessionController {
   private disposing = false;
   private disposePromise: Promise<void> | null = null;
   private shuttingDown = false;
-  private cleanedUp = false;
 
   public constructor(private readonly options: SessionControllerOptions) {}
 
@@ -49,7 +48,6 @@ export class SessionController {
   ): Promise<void> {
     const sessionPath = await ensureSessionPath();
     this.repository = new SnapshotRepository(sessionPath);
-    this.cleanedUp = false;
     // A reused PID may have left a stale file/lock after a crash.
     await clearSessionArtifacts(sessionPath);
 
@@ -119,11 +117,6 @@ export class SessionController {
     const snapshot = await repository.read();
     if (!snapshot || snapshot.revision <= this.lastAppliedRevision) return;
 
-    if (snapshot.revision === this.lastWrittenRevision) {
-      this.lastAppliedRevision = snapshot.revision;
-      return;
-    }
-
     if (snapshot.state.pendingReset) {
       const flattenHandlers = this.options.onReset();
       const webSocket = this.options.onResetWebSocket?.() ?? previousWebSocket(snapshot);
@@ -154,9 +147,8 @@ export class SessionController {
       await this.syncQueue;
       this.unregisterExitHandler();
       const sessionPath = this.sessionPath;
-      if (sessionPath && !this.cleanedUp) {
+      if (sessionPath) {
         await clearSessionArtifacts(sessionPath);
-        this.cleanedUp = true;
       }
       this.repository = null;
     })();
@@ -164,8 +156,7 @@ export class SessionController {
   }
 
   private async startWatching(): Promise<void> {
-    const repository = this.repository;
-    if (!repository) return;
+    const repository = this.repository!;
 
     await this.stopWatching();
     try {

--- a/packages/core/src/node/snapshot/controller.watcher.test.ts
+++ b/packages/core/src/node/snapshot/controller.watcher.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { http } from "msw";
+import { FlattenHandler, HttpMethod } from "../../shared/types";
+import { readSnapshot, writeSnapshot } from "./file";
+import { bumpSnapshot } from "./serialize";
+
+const watcherState = vi.hoisted(() => {
+  let allHandler: ((event: string) => void) | undefined;
+  const watcher = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "all") allHandler = handler as (event: string) => void;
+      return watcher;
+    }),
+    close: vi.fn(async () => undefined),
+  };
+
+  return {
+    watcher,
+    emit(event: string) {
+      allHandler?.(event);
+    },
+    reset() {
+      allHandler = undefined;
+      watcher.on.mockClear();
+      watcher.close.mockClear();
+    },
+  };
+});
+
+vi.mock("chokidar", () => ({
+  watch: vi.fn(() => watcherState.watcher),
+}));
+
+import { SessionController } from "./controller";
+import { getSessionPathForPid } from "./sessionPath";
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+
+const createTempSessionPath = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msw-session-controller-watcher-"));
+  tempDirs.push(dir);
+  process.chdir(dir);
+  return getSessionPathForPid(process.pid, dir);
+};
+
+const createFlattenHandler = (): FlattenHandler => ({
+  id: "handler-a",
+  path: "/api/a",
+  method: HttpMethod.GET,
+  handler: http.get("https://controller.test/handler-a", () => new Response()),
+  behavior: "default",
+  type: "default",
+});
+
+beforeEach(() => {
+  watcherState.reset();
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  process.chdir(originalCwd);
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("SessionController file watching", () => {
+  it("debounces consecutive file changes into one synchronization", async () => {
+    const sessionPath = createTempSessionPath();
+    const onSnapshot = vi.fn();
+    const controller = new SessionController({ onSnapshot, onReset: () => [] });
+
+    await controller.start([createFlattenHandler()]);
+    const seeded = (await readSnapshot(sessionPath))!;
+    await writeSnapshot(
+      sessionPath,
+      bumpSnapshot(seeded, {
+        flattenHandlers: seeded.state.flattenHandlers.map((handler) => ({
+          ...handler,
+          behavior: "delay",
+        })),
+      }),
+    );
+
+    watcherState.emit("change");
+    watcherState.emit("change");
+    await vi.advanceTimersByTimeAsync(24);
+    expect(onSnapshot).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await controller.sync();
+    expect(onSnapshot).toHaveBeenCalledOnce();
+    await controller.dispose();
+  });
+
+  it("ignores watcher events that do not add or change the session file", async () => {
+    const sessionPath = createTempSessionPath();
+    const onSnapshot = vi.fn();
+    const controller = new SessionController({ onSnapshot, onReset: () => [] });
+
+    await controller.start([createFlattenHandler()]);
+    const seeded = (await readSnapshot(sessionPath))!;
+    await writeSnapshot(sessionPath, bumpSnapshot(seeded, { mockEnabled: false }));
+
+    watcherState.emit("unlink");
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(onSnapshot).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
+
+  it("handles only the first termination signal during shutdown", async () => {
+    createTempSessionPath();
+    const controller = new SessionController({ onSnapshot: vi.fn(), onReset: () => [] });
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    try {
+      await controller.start([createFlattenHandler()]);
+      const signalHandler = (
+        controller as unknown as {
+          signalHandlers: Map<NodeJS.Signals, () => void>;
+        }
+      ).signalHandlers.get("SIGTERM");
+      if (!signalHandler) throw new Error("Expected SIGTERM handler");
+      signalHandler();
+      signalHandler();
+
+      await controller.dispose();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(kill).toHaveBeenCalledOnce();
+      expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    } finally {
+      kill.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -313,6 +313,7 @@ describe("snapshot file protocol", () => {
       }),
       expect.objectContaining({ id: "b" }),
     ]);
+    expect(next.state.flattenHandlers[1]!.customResponse).toBeUndefined();
   });
 
   it("mutates HTTP and global mock enabled state without changing other settings", async () => {

--- a/packages/core/src/node/snapshot/snapshot.test.ts
+++ b/packages/core/src/node/snapshot/snapshot.test.ts
@@ -207,6 +207,114 @@ describe("snapshot file protocol", () => {
     });
   });
 
+  it("changes only the requested handler behavior in a multi-handler snapshot", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await writeSnapshot(
+      sessionPath,
+      bumpSnapshot(createEmptySnapshot(), {
+        flattenHandlers: [
+          {
+            id: "a",
+            path: "/a",
+            method: HttpMethod.GET,
+            behavior: HttpHandlerBehavior.DEFAULT,
+            type: "default",
+          },
+          {
+            id: "b",
+            path: "/b",
+            method: HttpMethod.POST,
+            behavior: HttpHandlerBehavior.DEFAULT,
+            type: "default",
+          },
+        ],
+      }),
+    );
+
+    const next = await setSnapshotBehavior(sessionPath, "a", HttpHandlerBehavior.DELAY);
+
+    expect(next.state.flattenHandlers).toEqual([
+      expect.objectContaining({ id: "a", behavior: HttpHandlerBehavior.DELAY }),
+      expect.objectContaining({ id: "b", behavior: HttpHandlerBehavior.DEFAULT }),
+    ]);
+  });
+
+  it("changes only the requested handler enabled state in a multi-handler snapshot", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await writeSnapshot(
+      sessionPath,
+      bumpSnapshot(createEmptySnapshot(), {
+        flattenHandlers: [
+          {
+            id: "a",
+            path: "/a",
+            method: HttpMethod.GET,
+            behavior: HttpHandlerBehavior.DEFAULT,
+            enabled: true,
+            type: "default",
+          },
+          {
+            id: "b",
+            path: "/b",
+            method: HttpMethod.POST,
+            behavior: HttpHandlerBehavior.DEFAULT,
+            enabled: true,
+            type: "default",
+          },
+        ],
+      }),
+    );
+
+    const next = await setSnapshotHandlerEnabled(sessionPath, "a", false);
+
+    expect(next.state.flattenHandlers).toEqual([
+      expect.objectContaining({ id: "a", enabled: false }),
+      expect.objectContaining({ id: "b", enabled: true }),
+    ]);
+  });
+
+  it("changes only the requested handler custom response in a multi-handler snapshot", async () => {
+    const dir = makeTempDir();
+    const sessionPath = path.join(dir, "session.json");
+    await writeSnapshot(
+      sessionPath,
+      bumpSnapshot(createEmptySnapshot(), {
+        flattenHandlers: [
+          {
+            id: "a",
+            path: "/a",
+            method: HttpMethod.GET,
+            behavior: HttpHandlerBehavior.DEFAULT,
+            type: "default",
+          },
+          {
+            id: "b",
+            path: "/b",
+            method: HttpMethod.POST,
+            behavior: HttpHandlerBehavior.DEFAULT,
+            type: "default",
+          },
+        ],
+      }),
+    );
+
+    const next = await setSnapshotCustomResponse(sessionPath, "a", {
+      status: StringHttpStatusCode.CREATED,
+      response: "created",
+      contentType: MimeType.TEXT_PLAIN,
+    });
+
+    expect(next.state.flattenHandlers).toEqual([
+      expect.objectContaining({
+        id: "a",
+        customResponse: expect.objectContaining({ response: "created" }),
+      }),
+      expect.objectContaining({ id: "b" }),
+    ]);
+  });
+
   it("mutates HTTP and global mock enabled state without changing other settings", async () => {
     const dir = makeTempDir();
     const sessionPath = path.join(dir, "session.json");
@@ -640,6 +748,23 @@ describe("snapshot file protocol", () => {
     await writeSnapshot(sessionPath, createEmptySnapshot());
     expect(sessionPath).toBe(path.join(dir, ".msw-dev-tool", "sessions", "4182.json"));
     expect(await listSessionPids(dir)).toEqual([4182]);
+  });
+
+  it("returns no session PIDs when the sessions directory does not exist", async () => {
+    const dir = makeTempDir();
+
+    await expect(listSessionPids(dir)).resolves.toEqual([]);
+  });
+
+  it("ignores session files that do not contain numeric PIDs", async () => {
+    const dir = makeTempDir();
+    const sessionsDir = path.join(dir, ".msw-dev-tool", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, "not-a-pid.json"), "{}");
+    fs.writeFileSync(path.join(sessionsDir, "4182.json"), "{}");
+    fs.writeFileSync(path.join(sessionsDir, "notes.txt"), "{}");
+
+    await expect(listSessionPids(dir)).resolves.toEqual([4182]);
   });
 
   it("applies sequential locked mutations without lost updates", async () => {

--- a/packages/core/src/shared/domain/tempHandler.test.ts
+++ b/packages/core/src/shared/domain/tempHandler.test.ts
@@ -240,6 +240,6 @@ describe("rehydrateTempHandlers", () => {
     expect(getBehavior).toHaveBeenCalledWith(tempId);
     expect(getCustomResponse).toHaveBeenCalledWith(tempId);
     expect(getEnabled).toHaveBeenCalledWith(tempId);
-    expect(getMockEnabled).toHaveBeenCalled();
+    expect(getMockEnabled).toHaveBeenCalledWith();
   });
 });

--- a/packages/core/src/shared/domain/tempHandler.test.ts
+++ b/packages/core/src/shared/domain/tempHandler.test.ts
@@ -205,4 +205,41 @@ describe("rehydrateTempHandlers", () => {
       ),
     ).toEqual([]);
   });
+
+  it("rehydrates temporary handlers with current behavior and state callbacks", async () => {
+    const getBehavior = vi.fn(() => CustomBehavior.RETURN_NULL);
+    const getCustomResponse = vi.fn();
+    const getEnabled = vi.fn(() => true);
+    const getMockEnabled = vi.fn(() => true);
+    const tempId = getRowId({ path: baseInput.path, method: baseInput.method });
+
+    const result = rehydrateTempHandlers(
+      [
+        createFlattenHandler({
+          id: tempId,
+          path: baseInput.path,
+          method: baseInput.method,
+          type: "temp",
+          behavior: CustomBehavior.DEFAULT,
+          tempInput: baseInput,
+        }),
+      ],
+      getBehavior,
+      getCustomResponse,
+      getEnabled,
+      getMockEnabled,
+    );
+    const response = await result[0]!.handler.resolver({
+      request: new Request("http://localhost/temp", { method: "POST" }),
+      requestId: "1",
+      params: {},
+      cookies: {},
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect(getBehavior).toHaveBeenCalledWith(tempId);
+    expect(getCustomResponse).toHaveBeenCalledWith(tempId);
+    expect(getEnabled).toHaveBeenCalledWith(tempId);
+    expect(getMockEnabled).toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/shared/store/createStore.test.ts
+++ b/packages/core/src/shared/store/createStore.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStore } from "./createStore";
+
+describe("createStore", () => {
+  it("hydrates persisted state before exposing the store", () => {
+    const write = vi.fn();
+    const store = createStore(() => ({ count: 1 }), {
+      name: "counter",
+      partialize: (state) => state,
+      getStoredState: () => ({ count: 4 }),
+      write,
+    });
+
+    expect(store.getState()).toEqual({ count: 4 });
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("applies object and functional updates and notifies active subscribers", () => {
+    const write = vi.fn();
+    const listener = vi.fn();
+    const store = createStore(() => ({ count: 1 }), {
+      name: "counter",
+      partialize: (state) => state,
+      getStoredState: () => undefined,
+      write,
+    });
+    const unsubscribe = store.subscribe(listener);
+
+    store.setState({ count: 2 });
+    store.setState((state) => ({ count: state.count + 1 }));
+    unsubscribe();
+    store.setState({ count: 4 });
+
+    expect(store.getState()).toEqual({ count: 4 });
+    expect(write).toHaveBeenCalledTimes(3);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/shared/store/webSocketSlice.test.ts
+++ b/packages/core/src/shared/store/webSocketSlice.test.ts
@@ -218,6 +218,28 @@ describe("WebSocket state model", () => {
     ]);
   });
 
+  it("updates one listener enabled state and behavior without changing its sibling", () => {
+    const slice = createWebSocketSlice();
+    const endpointId = slice.addTempEndpoint({
+      endpoint: "ws://example.test/sibling",
+      matcher: { kind: "string", value: "ws://example.test/sibling" },
+    });
+    const first = slice.addTempListener({ endpointId });
+    const second = slice.addTempListener({ endpointId, behavior: { preset: "echo" } });
+
+    slice.setListenerEnabled(first, false);
+    slice.setListenerBehavior(first, { preset: "no-reply" });
+
+    expect(slice.getState().listeners).toEqual([
+      expect.objectContaining({ info: expect.objectContaining({ id: first }), enabled: false }),
+      expect.objectContaining({
+        info: expect.objectContaining({ id: second }),
+        enabled: true,
+        behavior: { preset: "echo" },
+      }),
+    ]);
+  });
+
   it("keeps code entries on reset and rejects deleting them", () => {
     const slice = createWebSocketSlice();
     const codeInfo = {

--- a/packages/core/src/shared/websocket/state.test.ts
+++ b/packages/core/src/shared/websocket/state.test.ts
@@ -246,13 +246,9 @@ describe("temporary WebSocket listener state", () => {
     );
 
     expect(changed.eventBranch.behavior).toEqual({ preset: "no-reply" });
-    expect(changed.endpoint.listeners).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          info: expect.objectContaining({ id: second.listener.info.id }),
-        }),
-      ]),
-    );
+    expect(
+      changed.endpoint.listeners.find((listener) => listener.info.id === second.listener.info.id),
+    ).toEqual(second.listener);
   });
 
   it("rejects a logical event update when the listener has no matching branch", () => {

--- a/packages/core/src/shared/websocket/state.test.ts
+++ b/packages/core/src/shared/websocket/state.test.ts
@@ -5,6 +5,7 @@ import {
   setWebSocketListenerBehavior,
   setWebSocketListenerCustomResponse,
   setWebSocketListenerResponse,
+  setWebSocketListenerEventBehavior,
   mergeDiscoveredWebSocketState,
   resetWebSocketEndpoints,
 } from "./state";
@@ -219,5 +220,52 @@ describe("temporary WebSocket listener state", () => {
       response: { delay: 300, repeat: { interval: 500, repetitions: "Infinity" } },
       customResponse: { delay: 100, repeat: { interval: 50, repetitions: 3 } },
     });
+  });
+
+  it("updates one logical event branch without changing a sibling listener", () => {
+    const initial = endpoint("ws://state.test/routed");
+    const first = addTemporaryWebSocketListener([initial], initial.endpointId, {});
+    const withBranch = first.endpoints.map((entry) => ({
+      ...entry,
+      listeners: entry.listeners.map((listener) => ({
+        ...listener,
+        eventBranches: [
+          { eventType: "chat/message", enabled: true, behavior: { preset: "default" as const } },
+        ],
+      })),
+    }));
+    const second = addTemporaryWebSocketListener(withBranch, initial.endpointId, {
+      behavior: { preset: "echo" },
+    });
+
+    const changed = setWebSocketListenerEventBehavior(
+      second.endpoints,
+      first.listener.info.id,
+      "chat/message",
+      { preset: "no-reply" },
+    );
+
+    expect(changed.eventBranch.behavior).toEqual({ preset: "no-reply" });
+    expect(changed.endpoint.listeners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          info: expect.objectContaining({ id: second.listener.info.id }),
+        }),
+      ]),
+    );
+  });
+
+  it("rejects a logical event update when the listener has no matching branch", () => {
+    const created = addTemporaryWebSocketListener(
+      [endpoint("ws://state.test/missing-event")],
+      endpoint("ws://state.test/missing-event").endpointId,
+      {},
+    );
+
+    expect(() =>
+      setWebSocketListenerEventBehavior(created.endpoints, created.listener.info.id, "missing", {
+        preset: "echo",
+      }),
+    ).toThrow("WebSocket listener event not found");
   });
 });

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -5,9 +5,9 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.{ts,tsx}"],
-      exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts"],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts", "src/shared/testing/**"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
+      thresholds: { statements: 95, branches: 95, functions: 95, lines: 95 },
     },
     projects: [
       {

--- a/packages/node-cli/src/cli/session.test.ts
+++ b/packages/node-cli/src/cli/session.test.ts
@@ -519,6 +519,34 @@ describe("FileSnapshotCliSession", () => {
     await missing;
   });
 
+  it("reports an enabled-state change when its handler is no longer in the snapshot", async () => {
+    vi.useFakeTimers();
+    api.setSnapshotHandlerEnabled.mockReturnValue(snapshot([]));
+    const session = new FileSnapshotCliSession(sessionPath);
+    const assertion = expect(session.setEnabled("a", false)).rejects.toThrow("Handler not found");
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    await assertion;
+  });
+
+  it("reports a custom-response change when its handler is no longer in the snapshot", async () => {
+    vi.useFakeTimers();
+    api.setSnapshotCustomResponse.mockReturnValue(snapshot([]));
+    const session = new FileSnapshotCliSession(sessionPath);
+    const assertion = expect(
+      session.setCustomResponse("a", {
+        status: "200",
+        contentType: "text/plain",
+        response: "ok",
+      }),
+    ).rejects.toThrow("Handler not found");
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    await assertion;
+  });
+
   it("reports a temporary handler creation when the handler is absent from the snapshot", async () => {
     vi.useFakeTimers();
     api.addSnapshotTempHandler.mockReturnValue(snapshot([]));
@@ -530,5 +558,25 @@ describe("FileSnapshotCliSession", () => {
     await vi.advanceTimersByTimeAsync(300);
 
     await assertion;
+  });
+
+  it("returns an empty endpoint list when endpoint removal omits WebSocket state", async () => {
+    vi.useFakeTimers();
+    const session = createWebSocketSession();
+    api.removeSnapshotWebSocketEndpoint.mockReturnValue(snapshot());
+
+    await expect(settleMutation(session.removeWebSocketEndpoint("ws-1"))).resolves.toEqual({
+      endpoints: [],
+    });
+  });
+
+  it("returns an empty endpoint list when listener removal omits WebSocket state", async () => {
+    vi.useFakeTimers();
+    const session = createWebSocketSession();
+    api.removeSnapshotWebSocketListener.mockReturnValue(snapshot());
+
+    await expect(
+      settleMutation(session.removeWebSocketListener(wsListener.info.id)),
+    ).resolves.toEqual({ endpoints: [] });
   });
 });

--- a/packages/node-cli/vitest.config.mts
+++ b/packages/node-cli/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
       reporter: ["text", "lcov"],
-      thresholds: { statements: 85, branches: 85, functions: 85, lines: 85 },
+      thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Abstract

<!-- What is the purpose of this PR? -->
- set tc coverage threshold to 95
- To achieve this, add missing tc
- To achieve this, remove unnecessary logic

## Issues

<!-- If there are any issues that this PR fixes, please list them here. -->
<!-- #(issue_number) -->
close #208 

## Description

<!-- How does this PR fix the issues? -->

## Spec

### Removed Spec

None

### Changed Spec

| Before | After |
| ------ | ----- |
| Coverage gates used lower package and Codecov targets. | Core coverage and Codecov project/patch coverage require at least 95%. |

### Added Spec

None

## Additional Context

<!-- Any other context that would be helpful to review the PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI validation for missing arguments and invalid boolean or JSON values.
  - Improved handling of browser connection failures, timeouts, and unavailable page targets.
  - Corrected WebSocket listener updates so changes remain isolated to the selected listener or event.
  - Improved session snapshot cleanup, synchronization, and file-watching behavior.
  - Added clearer fallback errors for unsuccessful browser evaluations.

- **Tests**
  - Expanded coverage across browser, node, core, snapshot, store, and WebSocket workflows.
  - Increased coverage requirements for key packages to 95–100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->