### PR TITLE
feat(core): interpolate WebSocket response templates

### DIFF
--- a/packages/core/src/msw/websocket.runtime.test.ts
+++ b/packages/core/src/msw/websocket.runtime.test.ts
@@ -50,6 +50,8 @@ const waitFor = async (predicate: () => boolean, timeout = 2_000) => {
   }
 };
 
+const messageEvent = (data: unknown): MessageEvent => new MessageEvent("message", { data });
+
 describe("temporary WebSocket runtime", () => {
   it("applies temporary endpoint behavior and drops removed handlers from the runtime", async () => {
     const store = createHandlerStore<SetupServer>({
@@ -562,6 +564,132 @@ describe("closeWebSocketConnections", () => {
     });
     adapter.dispatchWebSocketMessage(endpointId, client, new Event("message"), listenerId);
     expect(client.send).toHaveBeenCalledWith("hello");
+  });
+
+  it("renders a configured listener response from the incoming event", async () => {
+    const { adapter, endpointId, listenerId, client, store } =
+      await setupCustomResponseHarness("listener-template");
+    store.getState().setWebSocketListenerResponse(listenerId, {
+      type: "send",
+      dataType: "string",
+      value: "user=${{event.data.userId}}",
+    });
+    store.getState().setWebSocketListenerBehavior(listenerId, { preset: "default" });
+
+    adapter.dispatchWebSocketMessage(
+      endpointId,
+      client,
+      messageEvent({ userId: "user-7" }),
+      listenerId,
+    );
+
+    expect(client.send).toHaveBeenCalledWith("user=user-7");
+  });
+
+  it("renders a configured listener custom response as JSON", async () => {
+    const { adapter, endpointId, listenerId, client, store } = await setupCustomResponseHarness(
+      "listener-custom-template",
+    );
+    store.getState().setWebSocketListenerCustomResponse(listenerId, {
+      type: "send",
+      dataType: "string",
+      value: '{"userId":"${{event.data.userId}}"}',
+    });
+
+    adapter.dispatchWebSocketMessage(
+      endpointId,
+      client,
+      messageEvent({ userId: "user-7" }),
+      listenerId,
+    );
+
+    expect(client.send).toHaveBeenCalledWith('{"userId":"user-7"}');
+  });
+
+  it("renders a logical branch response from the routed event data", async () => {
+    const { adapter, endpointId, listenerId, client, store } = await setupCustomResponseHarness(
+      "branch-template",
+      ["message"],
+    );
+    store.getState().setWebSocketListenerEventResponse(listenerId, "message", {
+      type: "send",
+      dataType: "string",
+      value: "branch=${{event.data.value}}",
+    });
+    store.getState().setWebSocketListenerEventBehavior(listenerId, "message", {
+      preset: "default",
+    });
+
+    adapter.dispatchWebSocketMessage(
+      endpointId,
+      client,
+      messageEvent({ value: "latest" }),
+      listenerId,
+      undefined,
+      "message",
+    );
+
+    expect(client.send).toHaveBeenCalledWith("branch=latest");
+  });
+
+  it("renders a logical branch custom response from the routed event data", async () => {
+    const { adapter, endpointId, listenerId, client, store } = await setupCustomResponseHarness(
+      "branch-custom-template",
+      ["message"],
+    );
+    store.getState().setWebSocketListenerEventCustomResponse(listenerId, "message", {
+      type: "send",
+      dataType: "string",
+      value: "custom=${{event.data.value}}",
+    });
+    store.getState().setWebSocketListenerEventBehavior(listenerId, "message", {
+      preset: "custom response",
+    });
+
+    adapter.dispatchWebSocketMessage(
+      endpointId,
+      client,
+      messageEvent({ value: "latest" }),
+      listenerId,
+      undefined,
+      "message",
+    );
+
+    expect(client.send).toHaveBeenCalledWith("custom=latest");
+  });
+
+  it("uses each incoming event data for independently delayed responses", async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, endpointId, listenerId, client, store } =
+        await setupCustomResponseHarness("event-template-schedule");
+      store.getState().setWebSocketListenerResponse(listenerId, {
+        type: "send",
+        dataType: "string",
+        value: "value=${{event.data.value}}",
+        delay: 100,
+      });
+      store.getState().setWebSocketListenerBehavior(listenerId, { preset: "default" });
+
+      adapter.dispatchWebSocketMessage(
+        endpointId,
+        client,
+        messageEvent({ value: "first" }),
+        listenerId,
+      );
+      adapter.dispatchWebSocketMessage(
+        endpointId,
+        client,
+        messageEvent({ value: "second" }),
+        listenerId,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.send).toHaveBeenNthCalledWith(1, "value=first");
+      expect(client.send).toHaveBeenNthCalledWith(2, "value=second");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("dispatches a configured ArrayBuffer response", async () => {

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -2,5 +2,6 @@ export * from "./types";
 export * from "./controlProtocol";
 export * from "./schema";
 export * from "./websocket/response";
+export { createWebSocketTemplateContext } from "./websocket/interpolation";
 export { createHttpTemplateContext } from "./httpInterpolation";
 export { createHttpResponseFromConfig } from "./utils/handler";

--- a/packages/core/src/shared/interpolation.test.ts
+++ b/packages/core/src/shared/interpolation.test.ts
@@ -15,6 +15,14 @@ const context = {
 };
 
 describe("interpolateText", () => {
+  it("renders WebSocket event data and nested properties through the event root", () => {
+    expect(
+      interpolateText("${{event.data}}/${{event.data.userId}}", {
+        event: { data: { userId: "user-7", role: "admin" } },
+      }),
+    ).toBe('{"userId":"user-7","role":"admin"}/user-7');
+  });
+
   it("renders allowed resolver values through dot paths", () => {
     expect(
       interpolateText(

--- a/packages/core/src/shared/interpolation.ts
+++ b/packages/core/src/shared/interpolation.ts
@@ -1,7 +1,7 @@
 export type TemplateContext = Record<string, unknown>;
 
 const tokenPattern = /\$\{\{([^{}]*)\}\}/g;
-const pathPattern = /^(request|requestId|params|cookies)(?:\.[A-Za-z0-9_-]+)*$/;
+const pathPattern = /^(request|requestId|params|cookies|event)(?:\.[A-Za-z0-9_-]+)*$/;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;

--- a/packages/core/src/shared/store/createHandlerStore.ts
+++ b/packages/core/src/shared/store/createHandlerStore.ts
@@ -22,7 +22,11 @@ import {
 import { createTemporaryWebSocketHandler } from "../../msw/websocket";
 import { webSocketEndpointsSchema } from "../schema/websocket";
 import { webSocketCloseOptionsSchema, webSocketSendOptionsSchema } from "../schema/websocket";
-import { CUSTOM_WEBSOCKET_RESPONSE_ERROR, toWebSocketSendData } from "../websocket/response";
+import {
+  CUSTOM_WEBSOCKET_RESPONSE_ERROR,
+  renderWebSocketResponse,
+  toWebSocketSendData,
+} from "../websocket/response";
 import { createHandlerRegistry } from "./commonSlice";
 import {
   createWebSocketSlice,
@@ -213,8 +217,10 @@ export const createHandlerStore = <TRuntime extends MswDevToolRuntime>(
             const schedule: ResponseSchedule = { cancelled: false };
             const run = () => {
               if (schedule.cancelled) return;
-              if (response.type === "send") client.send(toWebSocketSendData(response));
-              else client.close(response.code, response.reason);
+              if (response.type === "send") {
+                const messageEvent = isWebSocketMessageEvent(event) ? event : undefined;
+                client.send(toWebSocketSendData(renderWebSocketResponse(response, messageEvent)));
+              } else client.close(response.code, response.reason);
               count += 1;
               listenerSchedules.delete(schedule);
               if (

--- a/packages/core/src/shared/websocket/interpolation.ts
+++ b/packages/core/src/shared/websocket/interpolation.ts
@@ -1,0 +1,19 @@
+import type { WebSocketData } from "msw";
+import type { TemplateContext } from "../interpolation";
+
+const parseJsonObjectOrArray = (data: WebSocketData): WebSocketData | object => {
+  if (typeof data !== "string") return data;
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return typeof parsed === "object" && parsed !== null ? parsed : data;
+  } catch {
+    return data;
+  }
+};
+
+/** Creates the template context available to a user-configured WebSocket response. */
+export const createWebSocketTemplateContext = (
+  event: MessageEvent<WebSocketData>,
+): TemplateContext => ({
+  event: { data: parseJsonObjectOrArray(event.data) },
+});

--- a/packages/core/src/shared/websocket/response.test.ts
+++ b/packages/core/src/shared/websocket/response.test.ts
@@ -1,7 +1,121 @@
 import { describe, expect, it } from "vitest";
-import { getWebSocketControlledResponse, parseWebSocketHex, toWebSocketSendData } from "./response";
+import {
+  getWebSocketControlledResponse,
+  parseWebSocketHex,
+  renderWebSocketResponse,
+  toWebSocketSendData,
+} from "./response";
+import { createWebSocketTemplateContext } from "./interpolation";
+
+const messageEvent = (data: unknown): MessageEvent => new MessageEvent("message", { data });
 
 describe("WebSocket custom response payloads", () => {
+  it("parses JSON message data for nested event template paths", () => {
+    expect(createWebSocketTemplateContext(messageEvent('{"userId":"user-7"}'))).toEqual({
+      event: { data: { userId: "user-7" } },
+    });
+  });
+
+  it("keeps plain text message data as text in the template context", () => {
+    expect(createWebSocketTemplateContext(messageEvent("plain message"))).toEqual({
+      event: { data: "plain message" },
+    });
+  });
+
+  it("keeps malformed JSON message data as text in the template context", () => {
+    expect(createWebSocketTemplateContext(messageEvent("{malformed"))).toEqual({
+      event: { data: "{malformed" },
+    });
+  });
+
+  it("keeps JSON primitive message data as text in the template context", () => {
+    expect(createWebSocketTemplateContext(messageEvent("42"))).toEqual({
+      event: { data: "42" },
+    });
+  });
+
+  it("keeps binary message data in the template context", () => {
+    const data = new ArrayBuffer(1);
+    expect(createWebSocketTemplateContext(messageEvent(data))).toEqual({
+      event: { data },
+    });
+  });
+
+  it("renders a text response from the incoming event data", () => {
+    const response = renderWebSocketResponse(
+      { type: "send", dataType: "string", value: "user=${{event.data.userId}}" },
+      messageEvent({ userId: "user-7" }),
+    );
+
+    expect(response).toEqual({
+      type: "send",
+      dataType: "string",
+      value: "user=user-7",
+    });
+  });
+
+  it("interpolates JSON-looking strings without parsing or normalizing them", () => {
+    const response = renderWebSocketResponse(
+      {
+        type: "send",
+        dataType: "string",
+        value: ' {  "id": "${{event.data.userId}}", "duplicate": 1, "duplicate": 2 } ',
+      },
+      messageEvent({ userId: "user-7" }),
+    );
+
+    expect(response.value).toBe(' {  "id": "user-7", "duplicate": 1, "duplicate": 2 } ');
+  });
+
+  it("keeps an unresolved event token in the response text", () => {
+    const unresolved = renderWebSocketResponse(
+      { type: "send", dataType: "string", value: "${{event.data.missing}}" },
+      messageEvent({ userId: "user-7" }),
+    );
+
+    expect(unresolved.value).toBe("${{event.data.missing}}");
+  });
+
+  it("keeps malformed JSON response text available to the client", () => {
+    const malformed = renderWebSocketResponse(
+      { type: "send", dataType: "string", value: '{"id":${{event.data.userId}}' },
+      messageEvent({ userId: "user-7" }),
+    );
+
+    expect(malformed.value).toBe('{"id":user-7');
+  });
+
+  it("leaves a binary response unchanged when an event is available", () => {
+    const binary = {
+      type: "send" as const,
+      dataType: "ArrayBuffer" as const,
+      value: "68 69",
+    };
+
+    expect(renderWebSocketResponse(binary, messageEvent({ value: "ignored" }))).toBe(binary);
+  });
+
+  it("leaves a close response unchanged when an event is available", () => {
+    const close = { type: "close" as const, code: 4001, reason: "${{event.data}}" };
+
+    expect(renderWebSocketResponse(close, messageEvent({ value: "ignored" }))).toBe(close);
+  });
+
+  it("leaves a static string response unchanged", () => {
+    expect(
+      renderWebSocketResponse(
+        { type: "send", dataType: "string", value: "static" },
+        messageEvent({ value: "ignored" }),
+      ),
+    ).toEqual({ type: "send", dataType: "string", value: "static" });
+  });
+
+  it("leaves a templated response unchanged when no event is provided", () => {
+    expect(
+      renderWebSocketResponse({ type: "send", dataType: "string", value: "${{event.data}}" }),
+    ).toEqual({ type: "send", dataType: "string", value: "${{event.data}}" });
+  });
+
   it("parses case-insensitive hexadecimal bytes", () => {
     expect(Array.from(parseWebSocketHex("68 65 6C 6C 6F"))).toEqual([104, 101, 108, 108, 111]);
   });

--- a/packages/core/src/shared/websocket/response.ts
+++ b/packages/core/src/shared/websocket/response.ts
@@ -4,6 +4,8 @@ import type {
   WebSocketListenerConfig,
   WebSocketResponseConfig,
 } from "../types";
+import { interpolateText } from "../interpolation";
+import { createWebSocketTemplateContext } from "./interpolation";
 
 export const CUSTOM_WEBSOCKET_RESPONSE_ERROR =
   "Please configure a custom response before using this behavior.";
@@ -13,6 +15,33 @@ export const getWebSocketControlledResponse = (
   field: "response" | "customResponse",
   branch?: WebSocketEventBranchConfig,
 ): WebSocketResponseConfig | undefined => (branch ? branch[field] : listener[field]);
+
+/** Renders only string WebSocket payloads; binary and close settings stay unchanged. */
+export function renderWebSocketResponse(
+  response: Extract<WebSocketResponseConfig, { type: "send" }>,
+  event?: MessageEvent<WebSocketData>,
+): Extract<WebSocketResponseConfig, { type: "send" }>;
+export function renderWebSocketResponse(
+  response: Extract<WebSocketResponseConfig, { type: "close" }>,
+  event?: MessageEvent<WebSocketData>,
+): Extract<WebSocketResponseConfig, { type: "close" }>;
+export function renderWebSocketResponse(
+  response: WebSocketResponseConfig,
+  event?: MessageEvent<WebSocketData>,
+): WebSocketResponseConfig {
+  if (
+    !event ||
+    response.type !== "send" ||
+    response.dataType !== "string" ||
+    !response.value.includes("${{")
+  ) {
+    return response;
+  }
+
+  const context = createWebSocketTemplateContext(event);
+  const value = interpolateText(response.value, context);
+  return { ...response, value };
+}
 
 export const parseWebSocketHex = (value: string): Uint8Array => {
   const tokens = value.trim().split(/\s+/);


### PR DESCRIPTION
## Abstract

Add variable interpolation to user-configured WebSocket response payloads, using data from the incoming message event.

## Issues

Closes #211

## Description

Configured WebSocket listener responses, custom responses, and logical event branch responses can use `${{event.data}}` and nested paths such as `${{event.data.userId}}`.

Interpolation runs when the response is actually sent, after any configured delay, and each scheduled response keeps the incoming event associated with that message. Incoming string message data is parsed only when it contains a JSON object or array so nested properties can be addressed; plain text, malformed JSON, JSON primitives, and binary data remain unchanged. Code-defined `client.send()` calls, binary response payloads, and close responses keep their existing behavior.

## Spec

### Removed Spec

None

### Changed Spec

| Before | After |
| ------ | ----- |
| A configured WebSocket string response containing `${{...}}` was sent with the template marker unchanged. | A configured WebSocket string response replaces supported event variables immediately before sending, including `${{event.data}}` and nested paths such as `${{event.data.userId}}`. |

### Added Spec

- User-configured WebSocket string responses can interpolate incoming message event data.
- Interpolation is available for listener responses, custom responses, and logical event branch responses.
- Delayed responses retain the incoming event associated with each scheduled response.

## Additional Context

- **Response contract:** Core treats configured `dataType: "string"` responses as text and only replaces template markers; JSON parsing, validity, and escaping remain the consuming application's responsibility.
- Added unit and runtime coverage for event contexts, listener/custom/branch responses, unresolved templates, delayed responses, and binary/close fallbacks.
- No CLI, React UI, or product documentation changes are included.
- `yarn test`, core coverage, typecheck, ESLint, Prettier, and `git diff --check` pass.
